### PR TITLE
feat: page results + historique démo localStorage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ Thumbs.db
 .idea/
 *.swp
 *.swo
+
+# Local documentation
+CLAUDE.md
+DEV_LOG.md

--- a/backend/database.py
+++ b/backend/database.py
@@ -5,9 +5,10 @@ import os
 
 load_dotenv()
 
-DATABASE_URL = os.getenv("DATABASE_URL")
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./backtesting.db")
 
-engine = create_engine(DATABASE_URL)
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
 
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -92,8 +92,22 @@ def lancer_backtest(request: BacktestRequest, db: Session = Depends(get_db)):
         raise HTTPException(status_code=422, detail=f"Paramètres invalides : {e}")
 
     df_signals = strategy.compute_signals(df)
-    results    = run_backtest(df_signals)
-    stats      = results["stats"]
+
+    if df_signals.empty:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Pas assez de données ({len(df)} barres) pour calculer les indicateurs "
+                f"avec ces paramètres. Essayez une période plus longue ou réduisez la fenêtre lente."
+            ),
+        )
+
+    try:
+        results = run_backtest(df_signals)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    stats = results["stats"]
 
     # Sauvegarde en DB si l'utilisateur est connecté
     if request.user_id:

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -44,13 +44,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
+                  "maximumWarning": "600kB",
                   "maximumError": "1MB"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "10kB",
+                  "maximumError": "20kB"
                 }
               ],
               "outputHashing": "all"

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,13 +1,10 @@
 import { Component, signal } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
-import { MatButtonModule } from '@angular/material/button';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { Navbar } from './components/navbar/navbar';
 
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, MatButtonModule, MatSlideToggleModule, Navbar],
+  imports: [Navbar],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })

--- a/frontend/src/app/components/equity-chart/equity-chart.html
+++ b/frontend/src/app/components/equity-chart/equity-chart.html
@@ -1,0 +1,3 @@
+<div class="chart-wrapper">
+  <div class="chart-host" #chartHost></div>
+</div>

--- a/frontend/src/app/components/equity-chart/equity-chart.scss
+++ b/frontend/src/app/components/equity-chart/equity-chart.scss
@@ -1,0 +1,21 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
+.chart-wrapper {
+  width: 100%;
+}
+
+.chart-host {
+  width: 100%;
+  height: 400px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+@media (max-width: 768px) {
+  .chart-host {
+    height: 260px;
+  }
+}

--- a/frontend/src/app/components/equity-chart/equity-chart.ts
+++ b/frontend/src/app/components/equity-chart/equity-chart.ts
@@ -1,0 +1,154 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
+import {
+  ColorType,
+  createChart,
+  IChartApi,
+  ISeriesApi,
+  LineSeries,
+} from 'lightweight-charts';
+import type { UTCTimestamp } from 'lightweight-charts';
+
+import type { EquityPoint } from '../../../services/data-service';
+
+@Component({
+  selector: 'app-equity-chart',
+  imports: [],
+  templateUrl: './equity-chart.html',
+  styleUrl: './equity-chart.scss',
+})
+export class EquityChartComponent implements AfterViewInit, OnChanges, OnDestroy {
+  @Input() equityCurve: EquityPoint[] = [];
+
+  @ViewChild('chartHost', { static: true })
+  private chartHostRef!: ElementRef<HTMLDivElement>;
+
+  private chart: IChartApi | null = null;
+  private seriesMarket: ISeriesApi<'Line'> | null = null;
+  private seriesStrat: ISeriesApi<'Line'> | null = null;
+  private resizeObserver: ResizeObserver | null = null;
+
+  ngAfterViewInit(): void {
+    this.initChart();
+    this.updateData();
+    this.setupResizeObserver();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!this.chart) return;
+    if (changes['equityCurve']) {
+      this.updateData();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
+    this.chart = null;
+    this.seriesMarket = null;
+    this.seriesStrat = null;
+  }
+
+  private initChart(): void {
+    const host = this.chartHostRef.nativeElement;
+
+    this.chart = createChart(host, {
+      autoSize: true,
+      layout: {
+        background: { type: ColorType.Solid, color: '#0f1216' },
+        textColor: '#d1d4dc',
+      },
+      grid: {
+        vertLines: { color: 'rgba(255, 255, 255, 0.06)' },
+        horzLines: { color: 'rgba(255, 255, 255, 0.06)' },
+      },
+      crosshair: { mode: 0 },
+      timeScale: {
+        timeVisible: true,
+        secondsVisible: false,
+      },
+      rightPriceScale: {
+        borderVisible: true,
+      },
+      handleScroll: true,
+      handleScale: true,
+    });
+
+    // Série marché en gris (en dessous pour la lisibilité)
+    this.seriesMarket = this.chart.addSeries(LineSeries, {
+      color: '#888888',
+      lineWidth: 2,
+      title: 'Marché',
+    });
+
+    // Série stratégie en bleu clair (au-dessus)
+    this.seriesStrat = this.chart.addSeries(LineSeries, {
+      color: '#4fc3f7',
+      lineWidth: 2,
+      title: 'Stratégie',
+    });
+  }
+
+  private setupResizeObserver(): void {
+    const host = this.chartHostRef.nativeElement;
+    if (typeof ResizeObserver === 'undefined') return;
+
+    this.resizeObserver = new ResizeObserver(() => {
+      if (!this.chart) return;
+      this.chart.applyOptions({
+        width: Math.max(host.clientWidth, 300),
+        height: Math.max(host.clientHeight, 300),
+      });
+    });
+
+    this.resizeObserver.observe(host);
+  }
+
+  private updateData(): void {
+    if (!this.chart || !this.seriesMarket || !this.seriesStrat) return;
+
+    const sorted = [...(this.equityCurve ?? [])]
+      .map(p => ({ ...p, _t: this.parseTimeToSeconds(p.Time) }))
+      .filter(p => p._t !== null && Number.isFinite(p._t))
+      .sort((a, b) => (a._t as number) - (b._t as number));
+
+    if (!sorted.length) {
+      this.seriesMarket.setData([]);
+      this.seriesStrat.setData([]);
+      return;
+    }
+
+    // Conversion en base 100 : (1 + rendement_cumulé) × 100
+    // Ex : cumulative_strat = 0.27 → valeur = 127 (i.e. +27%)
+    this.seriesMarket.setData(
+      sorted.map(p => ({
+        time: p._t as UTCTimestamp,
+        value: (1 + p.cumulative_market) * 100,
+      }))
+    );
+
+    this.seriesStrat.setData(
+      sorted.map(p => ({
+        time: p._t as UTCTimestamp,
+        value: (1 + p.cumulative_strat) * 100,
+      }))
+    );
+
+    this.chart.timeScale().fitContent();
+  }
+
+  private parseTimeToSeconds(timeStr: string): number | null {
+    if (!timeStr) return null;
+    const ms = Date.parse(timeStr.replace(' ', 'T'));
+    if (!Number.isFinite(ms)) return null;
+    return Math.floor(ms / 1000);
+  }
+}

--- a/frontend/src/app/pages/auth-callback/auth-callback.ts
+++ b/frontend/src/app/pages/auth-callback/auth-callback.ts
@@ -1,17 +1,20 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService } from '../../../services/auth.service';
+import { BacktestHistoryService } from '../../../services/backtest-history.service';
 
 @Component({
   selector: 'app-auth-callback',
   template: '',
 })
 export class AuthCallback implements OnInit {
-  private route = inject(ActivatedRoute);
-  private router = inject(Router);
-  private auth = inject(AuthService);
+  private route          = inject(ActivatedRoute);
+  private router         = inject(Router);
+  private auth           = inject(AuthService);
+  private historyService = inject(BacktestHistoryService);
 
   ngOnInit() {
+    this.historyService.clear();
     const params = this.route.snapshot.queryParams;
     if (params['user_id']) {
       this.auth.saveUser({

--- a/frontend/src/app/pages/backtests/backtests.ts
+++ b/frontend/src/app/pages/backtests/backtests.ts
@@ -1,4 +1,5 @@
 import { Component, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
@@ -39,7 +40,8 @@ const DEFAULT_PARAMS: Record<string, Record<string, number>> = {
 })
 export class Backtests {
   private dataService = inject(DataService);
-  private auth = inject(AuthService);
+  private auth        = inject(AuthService);
+  private router      = inject(Router);
 
   ticker   = signal<string>('sp500');
   period   = signal<string>('1Y');
@@ -79,6 +81,7 @@ export class Backtests {
       next: (data) => {
         this.result.set(data);
         this.isLoading.set(false);
+        this.router.navigate(['/results'], { state: { result: data } });
       },
       error: (err) => {
         const detail = err?.error?.detail ?? 'Impossible de joindre le serveur.';

--- a/frontend/src/app/pages/backtests/backtests.ts
+++ b/frontend/src/app/pages/backtests/backtests.ts
@@ -10,6 +10,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { DataService, BacktestResult } from '../../../services/data-service';
 import { AuthService } from '../../../services/auth.service';
+import { BacktestHistoryService } from '../../../services/backtest-history.service';
 
 const TICKER_MAP: Record<string, string> = {
   sp500:  '^GSPC',
@@ -42,6 +43,7 @@ export class Backtests {
   private dataService = inject(DataService);
   private auth        = inject(AuthService);
   private router      = inject(Router);
+  private historyService = inject(BacktestHistoryService);
 
   ticker   = signal<string>('sp500');
   period   = signal<string>('1Y');
@@ -79,6 +81,7 @@ export class Backtests {
       user_id:  this.auth.getUser()?.id,
     }).subscribe({
       next: (data) => {
+        this.historyService.push(data);
         this.result.set(data);
         this.isLoading.set(false);
         this.router.navigate(['/results'], { state: { result: data } });

--- a/frontend/src/app/pages/dashboard/dashboard.html
+++ b/frontend/src/app/pages/dashboard/dashboard.html
@@ -18,7 +18,7 @@
         <div class="stat-icon-wrap accent-blue">
           <mat-icon>history</mat-icon>
         </div>
-        <p class="stat-value">{{ totalBacktests() }}</p>
+        <p class="stat-value">{{ isDemo() ? demoHistory().length : totalBacktests() }}</p>
         <p class="stat-label">Backtests lancés</p>
       </mat-card-content>
     </mat-card>
@@ -28,7 +28,7 @@
         <div class="stat-icon-wrap accent-green">
           <mat-icon>trending_up</mat-icon>
         </div>
-        <p class="stat-value">{{ bestReturn() ? pct(bestReturn()!.total_return_strat) : '—' }}</p>
+        <p class="stat-value">{{ isDemo() ? (demoBestResult() ? pct(demoBestResult()!.stats.total_return_strat) : '—') : (bestReturn() ? pct(bestReturn()!.total_return_strat) : '—') }}</p>
         <p class="stat-label">Meilleur retour</p>
       </mat-card-content>
     </mat-card>
@@ -38,11 +38,56 @@
         <div class="stat-icon-wrap accent-purple">
           <mat-icon>emoji_events</mat-icon>
         </div>
-        <p class="stat-value">{{ bestReturn()?.strategy ?? '—' }}</p>
+        <p class="stat-value">{{ isDemo() ? (demoBestResult()?.strategy?.toUpperCase() ?? '—') : (bestReturn()?.strategy ?? '—') }}</p>
         <p class="stat-label">Meilleure stratégie</p>
       </mat-card-content>
     </mat-card>
   </div>
+
+  <!-- Dernier backtest démo -->
+  @if (isDemo() && lastDemo(); as last) {
+    <mat-card appearance="outlined" class="last-backtest-card">
+      <mat-card-header>
+        <mat-icon mat-card-avatar>bar_chart</mat-icon>
+        <mat-card-title>Dernier backtest</mat-card-title>
+        <mat-card-subtitle>{{ last.ticker }} — {{ last.strategy.toUpperCase() }}</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="last-stats">
+          <div class="last-stat">
+            <span class="lbl">Stratégie</span>
+            <span class="val" [class.positive]="last.stats.total_return_strat > 0"
+                              [class.negative]="last.stats.total_return_strat < 0">
+              {{ pct(last.stats.total_return_strat) }}
+            </span>
+          </div>
+          <div class="last-stat">
+            <span class="lbl">Marché</span>
+            <span class="val">{{ pct(last.stats.total_return_market) }}</span>
+          </div>
+          <div class="last-stat">
+            <span class="lbl">Sharpe</span>
+            <span class="val">{{ last.stats.sharpe_ratio.toFixed(2) }}</span>
+          </div>
+          <div class="last-stat">
+            <span class="lbl">Drawdown max</span>
+            <span class="val negative">{{ pct(last.stats.max_drawdown) }}</span>
+          </div>
+          <div class="last-stat">
+            <span class="lbl">Trades</span>
+            <span class="val">{{ last.stats.n_trades }}</span>
+          </div>
+          <div class="last-stat">
+            <span class="lbl">Win rate</span>
+            <span class="val">{{ pct(last.stats.win_rate) }}</span>
+          </div>
+        </div>
+      </mat-card-content>
+      <mat-card-actions>
+        <button mat-button routerLink="/results">Voir les résultats complets</button>
+      </mat-card-actions>
+    </mat-card>
+  }
 
   <!-- Derniers backtests -->
   @if (!isDemo() && recent().length > 0) {

--- a/frontend/src/app/pages/dashboard/dashboard.scss
+++ b/frontend/src/app/pages/dashboard/dashboard.scss
@@ -52,6 +52,26 @@
   color: var(--mat-sys-on-surface-variant);
 }
 
+/* Last backtest (demo) */
+.last-backtest-card mat-card-content {
+  padding-top: 12px;
+}
+
+.last-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 16px;
+}
+
+.last-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  .lbl { font-size: 0.75rem; color: var(--mat-sys-on-surface-variant); }
+  .val { font-size: 1.2rem; font-weight: 700; }
+}
+
 /* Recent */
 .recent-card mat-card-content {
   padding-top: 8px;

--- a/frontend/src/app/pages/dashboard/dashboard.ts
+++ b/frontend/src/app/pages/dashboard/dashboard.ts
@@ -6,7 +6,8 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
 import { AuthService } from '../../../services/auth.service';
-import { DataService, BacktestRecord } from '../../../services/data-service';
+import { DataService, BacktestRecord, BacktestResult } from '../../../services/data-service';
+import { BacktestHistoryService } from '../../../services/backtest-history.service';
 
 @Component({
   selector: 'app-dashboard',
@@ -15,13 +16,16 @@ import { DataService, BacktestRecord } from '../../../services/data-service';
   styleUrl: './dashboard.scss',
 })
 export class Dashboard implements OnInit {
-  private auth = inject(AuthService);
-  private dataService = inject(DataService);
+  private auth           = inject(AuthService);
+  private dataService    = inject(DataService);
+  private historyService = inject(BacktestHistoryService);
 
-  user    = signal(this.auth.getUser());
-  isDemo  = signal(this.auth.isDemoMode());
-  history = signal<BacktestRecord[]>([]);
-  loading = signal(true);
+  user     = signal(this.auth.getUser());
+  isDemo   = signal(this.auth.isDemoMode());
+  history  = signal<BacktestRecord[]>([]);
+  loading  = signal(true);
+  lastDemo   = signal<BacktestResult | null>(null);
+  demoHistory = signal<BacktestResult[]>([]);
 
   totalBacktests = computed(() => this.history().length);
   bestReturn     = computed(() => {
@@ -31,8 +35,22 @@ export class Dashboard implements OnInit {
   });
   recent = computed(() => this.history().slice(0, 3));
 
+  demoBestResult = computed(() => {
+    const h = this.demoHistory();
+    if (!h.length) return null;
+    return h.reduce((best, r) =>
+      r.stats.total_return_strat > best.stats.total_return_strat ? r : best
+    );
+  });
+
   ngOnInit() {
-    if (this.isDemo()) { this.loading.set(false); return; }
+    if (this.isDemo()) {
+      const all = this.historyService.getAll();
+      this.demoHistory.set(all);
+      this.lastDemo.set(all[0] ?? null);
+      this.loading.set(false);
+      return;
+    }
     const user = this.auth.getUser();
     if (!user) { this.loading.set(false); return; }
 

--- a/frontend/src/app/pages/results/results.html
+++ b/frontend/src/app/pages/results/results.html
@@ -1,82 +1,121 @@
-<div class="results-container">
-  <h2>Historique des backtests</h2>
+<div class="results-page">
 
-  @if (isDemo()) {
-    <p>Connectez-vous pour voir votre historique.</p>
-  } @else if (loading()) {
-    <p>Chargement...</p>
-  } @else if (history().length === 0) {
-    <p>Aucun backtest effectué pour l'instant.</p>
-  } @else {
-    <mat-card appearance="outlined">
-      <table mat-table [dataSource]="history()" matSort class="full-width">
+  <div class="page-header">
+    <button mat-button (click)="goBack()">
+      <mat-icon>arrow_back</mat-icon> Retour
+    </button>
+    <h1>Résultats du backtest</h1>
+  </div>
 
-        <ng-container matColumnDef="created_at">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Date</th>
-          <td mat-cell *matCellDef="let row">{{ row.created_at | date:'dd/MM/yy HH:mm' }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="ticker">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Ticker</th>
-          <td mat-cell *matCellDef="let row"><strong>{{ row.ticker }}</strong></td>
-        </ng-container>
-
-        <ng-container matColumnDef="strategy">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Stratégie</th>
-          <td mat-cell *matCellDef="let row">{{ row.strategy }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="period">
-          <th mat-header-cell *matHeaderCellDef>Période</th>
-          <td mat-cell *matCellDef="let row">{{ row.period }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="total_return_strat">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Retour strat</th>
-          <td mat-cell *matCellDef="let row" [class.positive]="row.total_return_strat > 0" [class.negative]="row.total_return_strat < 0">
-            {{ pct(row.total_return_strat) }}
-          </td>
-        </ng-container>
-
-        <ng-container matColumnDef="total_return_market">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Retour marché</th>
-          <td mat-cell *matCellDef="let row" [class.positive]="row.total_return_market > 0" [class.negative]="row.total_return_market < 0">
-            {{ pct(row.total_return_market) }}
-          </td>
-        </ng-container>
-
-        <ng-container matColumnDef="sharpe_ratio">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Sharpe</th>
-          <td mat-cell *matCellDef="let row">{{ row.sharpe_ratio | number:'1.2-2' }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="max_drawdown">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Drawdown</th>
-          <td mat-cell *matCellDef="let row" class="negative">{{ pct(row.max_drawdown) }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="n_trades">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Trades</th>
-          <td mat-cell *matCellDef="let row">{{ row.n_trades }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="win_rate">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>Win rate</th>
-          <td mat-cell *matCellDef="let row">{{ pct(row.win_rate) }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="actions">
-          <th mat-header-cell *matHeaderCellDef></th>
-          <td mat-cell *matCellDef="let row">
-            <button mat-icon-button color="warn" (click)="delete(row.id)" matTooltip="Supprimer">
-              <mat-icon>delete</mat-icon>
-            </button>
-          </td>
-        </ng-container>
-
-        <tr mat-header-row *matHeaderRowDef="columns"></tr>
-        <tr mat-row *matRowDef="let row; columns: columns"></tr>
-      </table>
-    </mat-card>
+  @if (!result()) {
+    <div class="empty-state">
+      <mat-icon>info</mat-icon>
+      <p>Aucun résultat disponible. Lancez un backtest depuis la page <a (click)="goBack()" style="cursor:pointer;color:#4fc3f7">Backtests</a>.</p>
+    </div>
   }
+
+  @if (result(); as res) {
+
+    <p class="subtitle">
+      {{ res.ticker }} — {{ res.strategy.toUpperCase() }}
+    </p>
+
+    <div class="stats-grid">
+      <mat-card>
+        <mat-card-content>
+          <div class="stat-label">Rendement stratégie</div>
+          <div class="stat-value"
+               [class.positive]="res.stats.total_return_strat > 0"
+               [class.negative]="res.stats.total_return_strat < 0">
+            {{ pct(res.stats.total_return_strat) }}
+          </div>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card>
+        <mat-card-content>
+          <div class="stat-label">Rendement marché</div>
+          <div class="stat-value"
+               [class.positive]="res.stats.total_return_market > 0"
+               [class.negative]="res.stats.total_return_market < 0">
+            {{ pct(res.stats.total_return_market) }}
+          </div>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card>
+        <mat-card-content>
+          <div class="stat-label">Ratio de Sharpe</div>
+          <div class="stat-value">{{ res.stats.sharpe_ratio.toFixed(2) }}</div>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card>
+        <mat-card-content>
+          <div class="stat-label">Drawdown max</div>
+          <div class="stat-value negative">{{ pct(res.stats.max_drawdown) }}</div>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card>
+        <mat-card-content>
+          <div class="stat-label">Trades</div>
+          <div class="stat-value">{{ res.stats.n_trades }}</div>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card>
+        <mat-card-content>
+          <div class="stat-label">Win rate</div>
+          <div class="stat-value">{{ pct(res.stats.win_rate) }}</div>
+        </mat-card-content>
+      </mat-card>
+    </div>
+
+    <mat-card class="chart-card">
+      <mat-card-header>
+        <mat-card-title>Courbe d'équité</mat-card-title>
+        <mat-card-subtitle>
+          <span class="legend-strat">— Stratégie</span>
+          &nbsp;&nbsp;
+          <span class="legend-market">— Marché (buy &amp; hold)</span>
+        </mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <app-equity-chart [equityCurve]="res.equity_curve" />
+      </mat-card-content>
+    </mat-card>
+
+    @if (res.signals.length > 0) {
+      <mat-card class="signals-card">
+        <mat-card-header>
+          <mat-card-title>Signaux ({{ res.signals.length }} barres)</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  @for (key of signalKeys(); track key) {
+                    <th>{{ key }}</th>
+                  }
+                </tr>
+              </thead>
+              <tbody>
+                @for (row of res.signals; track $index) {
+                  <tr>
+                    @for (key of signalKeys(); track key) {
+                      <td>{{ row[key] }}</td>
+                    }
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        </mat-card-content>
+      </mat-card>
+    }
+
+  }
+
 </div>

--- a/frontend/src/app/pages/results/results.html
+++ b/frontend/src/app/pages/results/results.html
@@ -7,7 +7,7 @@
     <h1>Résultats du backtest</h1>
   </div>
 
-  @if (!result()) {
+  @if (!result() && backtestHistory().length === 0) {
     <div class="empty-state">
       <mat-icon>info</mat-icon>
       <p>Aucun résultat disponible. Lancez un backtest depuis la page <a (click)="goBack()" style="cursor:pointer;color:#4fc3f7">Backtests</a>.</p>
@@ -18,6 +18,9 @@
 
     <p class="subtitle">
       {{ res.ticker }} — {{ res.strategy.toUpperCase() }}
+      @if (isDemoMode() && backtestHistory().length > 1) {
+        <span class="history-badge">Backtest {{ selectedIndex() + 1 }} / {{ backtestHistory().length }}</span>
+      }
     </p>
 
     <div class="stats-grid">
@@ -27,6 +30,7 @@
           <div class="stat-value"
                [class.positive]="res.stats.total_return_strat > 0"
                [class.negative]="res.stats.total_return_strat < 0">
+            <mat-icon class="stat-icon">{{ res.stats.total_return_strat >= 0 ? 'arrow_upward' : 'arrow_downward' }}</mat-icon>
             {{ pct(res.stats.total_return_strat) }}
           </div>
         </mat-card-content>
@@ -38,6 +42,7 @@
           <div class="stat-value"
                [class.positive]="res.stats.total_return_market > 0"
                [class.negative]="res.stats.total_return_market < 0">
+            <mat-icon class="stat-icon">{{ res.stats.total_return_market >= 0 ? 'arrow_upward' : 'arrow_downward' }}</mat-icon>
             {{ pct(res.stats.total_return_market) }}
           </div>
         </mat-card-content>
@@ -46,7 +51,9 @@
       <mat-card>
         <mat-card-content>
           <div class="stat-label">Ratio de Sharpe</div>
-          <div class="stat-value">{{ res.stats.sharpe_ratio.toFixed(2) }}</div>
+          <div class="stat-value" [class]="sharpeClass(res.stats.sharpe_ratio)">
+            {{ res.stats.sharpe_ratio.toFixed(2) }}
+          </div>
         </mat-card-content>
       </mat-card>
 
@@ -67,7 +74,11 @@
       <mat-card>
         <mat-card-content>
           <div class="stat-label">Win rate</div>
-          <div class="stat-value">{{ pct(res.stats.win_rate) }}</div>
+          <div class="stat-value"
+               [class.positive]="res.stats.win_rate >= 0.5"
+               [class.negative]="res.stats.win_rate < 0.5">
+            {{ pct(res.stats.win_rate) }}
+          </div>
         </mat-card-content>
       </mat-card>
     </div>
@@ -116,6 +127,83 @@
       </mat-card>
     }
 
+  }
+
+  @if (isDemoMode() && backtestHistory().length > 1) {
+    <mat-card class="history-card">
+      <mat-card-header>
+        <mat-card-title>Historique des backtests (démo)</mat-card-title>
+        <mat-card-subtitle>Cliquez sur une ligne pour afficher l'analyse complète</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <table mat-table [dataSource]="backtestHistory()" class="history-mat-table">
+
+          <ng-container matColumnDef="status">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let row; let i = index">
+              @if (selectedIndex() === i) {
+                <mat-icon class="active-dot" matTooltip="Affiché">fiber_manual_record</mat-icon>
+              }
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="ticker">
+            <th mat-header-cell *matHeaderCellDef>Ticker</th>
+            <td mat-cell *matCellDef="let row">
+              <strong>{{ row.ticker }}</strong>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="strategy">
+            <th mat-header-cell *matHeaderCellDef>Stratégie</th>
+            <td mat-cell *matCellDef="let row">
+              <span class="strategy-chip" [class]="strategyClass(row.strategy)">
+                {{ row.strategy.toUpperCase() }}
+              </span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="strat">
+            <th mat-header-cell *matHeaderCellDef>Strat</th>
+            <td mat-cell *matCellDef="let row"
+                [class.positive]="row.stats.total_return_strat > 0"
+                [class.negative]="row.stats.total_return_strat < 0">
+              <mat-icon class="inline-icon">{{ row.stats.total_return_strat >= 0 ? 'arrow_upward' : 'arrow_downward' }}</mat-icon>
+              {{ pct(row.stats.total_return_strat) }}
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="market">
+            <th mat-header-cell *matHeaderCellDef>Marché</th>
+            <td mat-cell *matCellDef="let row"
+                [class.positive]="row.stats.total_return_market > 0"
+                [class.negative]="row.stats.total_return_market < 0">
+              {{ pct(row.stats.total_return_market) }}
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="sharpe">
+            <th mat-header-cell *matHeaderCellDef>Sharpe</th>
+            <td mat-cell *matCellDef="let row" [class]="sharpeClass(row.stats.sharpe_ratio)">
+              {{ row.stats.sharpe_ratio.toFixed(2) }}
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="trades">
+            <th mat-header-cell *matHeaderCellDef>Trades</th>
+            <td mat-cell *matCellDef="let row">{{ row.stats.n_trades }}</td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="historyColumns"></tr>
+          <tr mat-row
+              *matRowDef="let row; columns: historyColumns; let i = index"
+              [class.active-row]="selectedIndex() === i"
+              (click)="selectBacktest(row, i)"
+              class="clickable-row">
+          </tr>
+        </table>
+      </mat-card-content>
+    </mat-card>
   }
 
 </div>

--- a/frontend/src/app/pages/results/results.scss
+++ b/frontend/src/app/pages/results/results.scss
@@ -1,12 +1,107 @@
-.results-container {
+.results-page {
+  padding: 24px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 8px;
+
+  h1 {
+    margin: 0;
+    font-size: 1.6rem;
+  }
+}
+
+.subtitle {
+  color: #aaa;
+  margin: 0 0 24px;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+  margin-bottom: 24px;
+
+  mat-card {
+    text-align: center;
+  }
+
+  .stat-label {
+    font-size: 0.75rem;
+    color: #aaa;
+    margin-bottom: 6px;
+  }
+
+  .stat-value {
+    font-size: 1.4rem;
+    font-weight: 600;
+
+    &.positive { color: #66bb6a; }
+    &.negative { color: #ef5350; }
+  }
+}
+
+.chart-card {
+  margin-bottom: 24px;
+
+  .legend-strat  { color: #4fc3f7; }
+  .legend-market { color: #888; }
+}
+
+.signals-card {
+  margin-bottom: 24px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  max-height: 320px;
+  overflow-y: auto;
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.8rem;
+
+    th, td {
+      padding: 6px 10px;
+      text-align: right;
+      white-space: nowrap;
+      border-bottom: 1px solid #333;
+    }
+
+    th {
+      position: sticky;
+      top: 0;
+      background: #1e1e1e;
+      color: #aaa;
+      font-weight: 600;
+    }
+
+    tr:hover td {
+      background: #2a2a2a;
+    }
+  }
+}
+
+.empty-state {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-}
+  align-items: center;
+  gap: 12px;
+  padding: 48px;
+  color: #aaa;
 
-.full-width {
-  width: 100%;
+  mat-icon {
+    font-size: 48px;
+    width: 48px;
+    height: 48px;
+  }
 }
-
-.positive { color: #4caf50; font-weight: 500; }
-.negative { color: #f44336; font-weight: 500; }

--- a/frontend/src/app/pages/results/results.scss
+++ b/frontend/src/app/pages/results/results.scss
@@ -17,6 +17,9 @@
 }
 
 .subtitle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   color: #aaa;
   margin: 0 0 24px;
   font-size: 0.95rem;
@@ -24,15 +27,24 @@
   text-transform: uppercase;
 }
 
+.history-badge {
+  font-size: 0.7rem;
+  background: #1e3a5f;
+  color: #4fc3f7;
+  padding: 2px 8px;
+  border-radius: 12px;
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
+/* Stats grid */
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
   gap: 12px;
   margin-bottom: 24px;
 
-  mat-card {
-    text-align: center;
-  }
+  mat-card { text-align: center; }
 
   .stat-label {
     font-size: 0.75rem;
@@ -41,14 +53,28 @@
   }
 
   .stat-value {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
     font-size: 1.4rem;
     font-weight: 600;
 
-    &.positive { color: #66bb6a; }
-    &.negative { color: #ef5350; }
+    &.positive    { color: #66bb6a; }
+    &.negative    { color: #ef5350; }
+    &.sharpe-good { color: #66bb6a; }
+    &.sharpe-ok   { color: #ffa726; }
+    &.sharpe-bad  { color: #ef5350; }
+
+    .stat-icon {
+      font-size: 1.1rem;
+      width: 1.1rem;
+      height: 1.1rem;
+    }
   }
 }
 
+/* Chart */
 .chart-card {
   margin-bottom: 24px;
 
@@ -56,9 +82,8 @@
   .legend-market { color: #888; }
 }
 
-.signals-card {
-  margin-bottom: 24px;
-}
+/* Signals table */
+.signals-card { margin-bottom: 24px; }
 
 .table-wrapper {
   overflow-x: auto;
@@ -85,12 +110,80 @@
       font-weight: 600;
     }
 
-    tr:hover td {
-      background: #2a2a2a;
-    }
+    tr:hover td { background: #2a2a2a; }
   }
 }
 
+/* History mat-table */
+.history-card { margin-bottom: 24px; }
+
+.history-mat-table {
+  width: 100%;
+
+  th.mat-header-cell {
+    color: #aaa;
+    font-size: 0.78rem;
+    font-weight: 600;
+  }
+
+  td.mat-cell {
+    font-size: 0.85rem;
+    vertical-align: middle;
+  }
+
+  /* Color classes inside cells */
+  td.positive { color: #66bb6a; font-weight: 600; }
+  td.negative { color: #ef5350; font-weight: 600; }
+  td.sharpe-good { color: #66bb6a; font-weight: 600; }
+  td.sharpe-ok   { color: #ffa726; font-weight: 600; }
+  td.sharpe-bad  { color: #ef5350; font-weight: 600; }
+
+  tr.clickable-row {
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  tr.clickable-row:hover td.mat-cell {
+    background: #252525;
+  }
+
+  tr.active-row td.mat-cell {
+    background: #1a2a3a;
+    font-weight: 600;
+  }
+
+  .active-dot {
+    font-size: 10px;
+    width: 10px;
+    height: 10px;
+    color: #4fc3f7;
+  }
+
+  .inline-icon {
+    font-size: 0.85rem;
+    width: 0.85rem;
+    height: 0.85rem;
+    vertical-align: middle;
+    margin-right: 2px;
+  }
+
+  /* Strategy chips */
+  .strategy-chip {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+
+    &.chip-macd    { background: #0d47a1; color: #90caf9; }
+    &.chip-rsi     { background: #4a148c; color: #ce93d8; }
+    &.chip-ma      { background: #004d40; color: #80cbc4; }
+    &.chip-default { background: #333;    color: #ccc; }
+  }
+}
+
+/* Empty state */
 .empty-state {
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/pages/results/results.ts
+++ b/frontend/src/app/pages/results/results.ts
@@ -1,27 +1,49 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { BacktestResult } from '../../../services/data-service';
 import { EquityChartComponent } from '../../components/equity-chart/equity-chart';
+import { BacktestHistoryService } from '../../../services/backtest-history.service';
+import { AuthService } from '../../../services/auth.service';
 
 @Component({
   selector: 'app-results',
-  imports: [MatButtonModule, MatCardModule, MatIconModule, EquityChartComponent],
+  imports: [MatButtonModule, MatCardModule, MatIconModule, MatTableModule, MatTooltipModule, EquityChartComponent],
   templateUrl: './results.html',
   styleUrl: './results.scss',
 })
 export class Results implements OnInit {
-  private router = inject(Router);
+  private router         = inject(Router);
+  private historyService = inject(BacktestHistoryService);
+  private auth           = inject(AuthService);
 
-  result = signal<BacktestResult | null>(null);
+  result          = signal<BacktestResult | null>(null);
+  backtestHistory = signal<BacktestResult[]>([]);
+  selectedIndex   = signal<number>(0);
+  isDemoMode      = computed(() => this.auth.isDemoMode());
+
+  historyColumns = ['status', 'ticker', 'strategy', 'strat', 'market', 'sharpe', 'trades'];
 
   ngOnInit() {
     const data = history.state?.['result'] as BacktestResult | undefined;
-    if (data) {
-      this.result.set(data);
+    if (data) this.result.set(data);
+    if (this.auth.isDemoMode()) {
+      const all = this.historyService.getAll();
+      this.backtestHistory.set(all);
+      if (!data && all.length > 0) {
+        this.result.set(all[0]);
+      }
     }
+  }
+
+  selectBacktest(entry: BacktestResult, index: number) {
+    this.result.set(entry);
+    this.selectedIndex.set(index);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
   goBack() {
@@ -30,6 +52,19 @@ export class Results implements OnInit {
 
   pct(value: number): string {
     return (value * 100).toFixed(2) + '%';
+  }
+
+  sharpeClass(v: number): string {
+    if (v >= 1)  return 'sharpe-good';
+    if (v >= 0)  return 'sharpe-ok';
+    return 'sharpe-bad';
+  }
+
+  strategyClass(s: string): string {
+    if (s === 'macd')         return 'chip-macd';
+    if (s === 'rsi')          return 'chip-rsi';
+    if (s === 'ma_crossover') return 'chip-ma';
+    return 'chip-default';
   }
 
   signalKeys(): string[] {

--- a/frontend/src/app/pages/results/results.ts
+++ b/frontend/src/app/pages/results/results.ts
@@ -1,58 +1,40 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
-import { DatePipe, DecimalPipe } from '@angular/common';
-import { MatTableModule } from '@angular/material/table';
-import { MatSortModule } from '@angular/material/sort';
-import { MatCardModule } from '@angular/material/card';
+import { Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-import { MatTooltipModule } from '@angular/material/tooltip';
-import { DataService, BacktestRecord } from '../../../services/data-service';
-import { AuthService } from '../../../services/auth.service';
+import { BacktestResult } from '../../../services/data-service';
+import { EquityChartComponent } from '../../components/equity-chart/equity-chart';
 
 @Component({
   selector: 'app-results',
-  imports: [
-    DatePipe, DecimalPipe,
-    MatTableModule, MatSortModule, MatCardModule,
-    MatButtonModule, MatIconModule, MatTooltipModule,
-  ],
+  imports: [MatButtonModule, MatCardModule, MatIconModule, EquityChartComponent],
   templateUrl: './results.html',
   styleUrl: './results.scss',
 })
 export class Results implements OnInit {
-  private dataService = inject(DataService);
-  private auth = inject(AuthService);
+  private router = inject(Router);
 
-  columns = ['created_at', 'ticker', 'strategy', 'period',
-             'total_return_strat', 'total_return_market',
-             'sharpe_ratio', 'max_drawdown', 'n_trades', 'win_rate', 'actions'];
-
-  history = signal<BacktestRecord[]>([]);
-  isDemo  = signal(false);
-  loading = signal(true);
+  result = signal<BacktestResult | null>(null);
 
   ngOnInit() {
-    if (this.auth.isDemoMode()) {
-      this.isDemo.set(true);
-      this.loading.set(false);
-      return;
+    const data = history.state?.['result'] as BacktestResult | undefined;
+    if (data) {
+      this.result.set(data);
     }
-    const user = this.auth.getUser();
-    if (!user) return;
-
-    this.dataService.getHistory(user.id).subscribe({
-      next: (data) => { this.history.set(data); this.loading.set(false); },
-      error: () => this.loading.set(false),
-    });
   }
 
-  delete(id: number) {
-    this.dataService.deleteBacktest(id).subscribe(() => {
-      this.history.update((h) => h.filter((r) => r.id !== id));
-    });
+  goBack() {
+    this.router.navigate(['/backtests']);
   }
 
-  pct(v: number): string {
-    return (v * 100).toFixed(2) + '%';
+  pct(value: number): string {
+    return (value * 100).toFixed(2) + '%';
+  }
+
+  signalKeys(): string[] {
+    const signals = this.result()?.signals;
+    if (!signals || signals.length === 0) return [];
+    return Object.keys(signals[0]);
   }
 }

--- a/frontend/src/services/backtest-history.service.ts
+++ b/frontend/src/services/backtest-history.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { BacktestResult } from './data-service';
+
+const STORAGE_KEY = 'demo_backtest_history';
+const MAX_ENTRIES = 5;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class BacktestHistoryService {
+
+  push(result: BacktestResult): void {
+    const current = this.getAll();
+    const updated = [result, ...current].slice(0, MAX_ENTRIES);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  }
+
+  getAll(): BacktestResult[] {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
+    } catch {
+      return [];
+    }
+  }
+
+  clear(): void {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}


### PR DESCRIPTION
## Ce qui a été fait

- Page `/results` fonctionnelle reliée au backend
- Courbe d'équité interactive (lightweight-charts)
- Historique des 5 derniers backtests en mode démo (localStorage)
- Tableau cliquable : cliquer sur un ancien backtest affiche son analyse complète
- Chips stratégies colorés, indicateurs Sharpe, flèches rendement
- Page `/dashboard` : stats démo (nb backtests, meilleur retour, meilleure stratégie)
- Carte "Dernier backtest" sur le dashboard en mode démo

## Tests
- Mode démo : lancer plusieurs backtests et vérifier l'historique sur /results
- Vérifier que les stats du dashboard se mettent à jour
- Login Google : vérifier que l'historique démo est vidé
