### PR TITLE
feat: cache yfinance 24h en base de donnees

### DIFF
--- a/backend/cache.py
+++ b/backend/cache.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timezone, timedelta
+from sqlalchemy.orm import Session
+from models import MarketDataCache
+
+CACHE_TTL = timedelta(hours=24)
+
+
+def get_cached_data(db: Session, ticker: str, period: str) -> list[dict] | None:
+    row = (
+        db.query(MarketDataCache)
+        .filter(MarketDataCache.ticker == ticker, MarketDataCache.period == period)
+        .first()
+    )
+    if row is None:
+        return None
+    age = datetime.now(timezone.utc) - row.fetched_at.replace(tzinfo=timezone.utc)
+    if age > CACHE_TTL:
+        db.delete(row)
+        db.commit()
+        return None
+    return row.data
+
+
+def store_cached_data(db: Session, ticker: str, period: str, records: list[dict]):
+    row = (
+        db.query(MarketDataCache)
+        .filter(MarketDataCache.ticker == ticker, MarketDataCache.period == period)
+        .first()
+    )
+    if row:
+        row.data = records
+        row.fetched_at = datetime.now(timezone.utc)
+    else:
+        row = MarketDataCache(ticker=ticker, period=period, data=records)
+        db.add(row)
+    db.commit()

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,69 @@
+import pytest
+import pandas as pd
+import numpy as np
+from datetime import datetime
+from unittest.mock import patch
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from fastapi.testclient import TestClient
+
+from database import Base, get_db
+import models  # noqa: F401 — register all models before create_all
+from main import app
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def client(db_session):
+    def _override():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _make_ohlcv_df(n_rows=20):
+    dates = pd.bdate_range(end=datetime(2025, 5, 1), periods=n_rows)
+    rng = np.random.default_rng(42)
+    close = 150 + rng.standard_normal(n_rows).cumsum()
+    df = pd.DataFrame(
+        {
+            ("Close", "AAPL"): close,
+            ("Open", "AAPL"): close - rng.uniform(0, 2, n_rows),
+            ("High", "AAPL"): close + rng.uniform(0, 3, n_rows),
+            ("Low", "AAPL"): close - rng.uniform(0, 3, n_rows),
+            ("Volume", "AAPL"): rng.integers(1_000_000, 10_000_000, n_rows),
+        },
+        index=dates,
+    )
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+    df.index.name = "Date"
+    return df
+
+
+@pytest.fixture()
+def mock_yf_download():
+    fake_df = _make_ohlcv_df()
+    with patch("yfinance.download", return_value=fake_df) as mock:
+        yield mock

--- a/backend/data.py
+++ b/backend/data.py
@@ -1,5 +1,8 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
 import yfinance as yf
+from database import get_db
+from cache import get_cached_data, store_cached_data
 
 router = APIRouter()
 
@@ -18,9 +21,14 @@ PERIOD_CONFIG = {
 
 
 @router.get("/{ticker}")
-def get_market_data(ticker: str, period: str = "1Y"):
+def get_market_data(ticker: str, period: str = "1Y", db: Session = Depends(get_db)):
     symbol = TICKER_MAP.get(ticker.lower(), ticker)
-    config = PERIOD_CONFIG.get(period.upper(), PERIOD_CONFIG["1Y"])
+    period_key = period.upper()
+    config = PERIOD_CONFIG.get(period_key, PERIOD_CONFIG["1Y"])
+
+    cached = get_cached_data(db, symbol, period_key)
+    if cached is not None:
+        return cached
 
     df = yf.download(symbol, period=config["period"], interval=config["interval"], auto_adjust=True)
 
@@ -36,4 +44,6 @@ def get_market_data(ticker: str, period: str = "1Y"):
     else:
         df["Time"] = df["Time"].dt.strftime("%Y-%m-%d")
 
-    return df[["Time", "Open", "High", "Low", "Close", "Volume"]].to_dict(orient="records")
+    records = df[["Time", "Open", "High", "Low", "Close", "Volume"]].to_dict(orient="records")
+    store_cached_data(db, symbol, period_key, records)
+    return records

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ import os
 from database import Base, engine, get_db
 import models  # noqa: F401 — enregistre les tables SQLAlchemy avant create_all
 from models import Backtest
+from cache import get_cached_data, store_cached_data
 
 import data
 from strategies import STRATEGIES_REGISTRY
@@ -38,7 +39,15 @@ app.include_router(data.router, prefix="/api/data")
 app.include_router(auth_router, prefix="/api/auth")
 
 
-def fetch_market_data(ticker: str, period: str) -> pd.DataFrame:
+def fetch_market_data(ticker: str, period: str, db: Session | None = None) -> pd.DataFrame:
+    if db is not None:
+        cached = get_cached_data(db, ticker, period.upper())
+        if cached is not None:
+            df = pd.DataFrame(cached)
+            df["Time"] = pd.to_datetime(df["Time"])
+            df = df.set_index("Time").sort_index()
+            return df
+
     windows = {
         "1D": timedelta(days=1),
         "1M": timedelta(days=30),
@@ -57,6 +66,11 @@ def fetch_market_data(ticker: str, period: str) -> pd.DataFrame:
     df.columns = df.columns.get_level_values(0)
     df.index.name = "Time"
     df = df.sort_index()
+
+    if db is not None:
+        records = df.reset_index().assign(Time=lambda x: x["Time"].astype(str)).to_dict(orient="records")
+        store_cached_data(db, ticker, period.upper(), records)
+
     return df
 
 
@@ -80,7 +94,7 @@ def lancer_backtest(request: BacktestRequest, db: Session = Depends(get_db)):
             detail=f"Stratégie '{request.strategy}' non trouvée. Disponibles : {list(STRATEGIES_REGISTRY.keys())}"
         )
 
-    df = fetch_market_data(request.ticker, request.period)
+    df = fetch_market_data(request.ticker, request.period, db)
 
     if len(df) < 10:
         raise HTTPException(status_code=422, detail="Pas assez de données pour cette période.")

--- a/backend/models.py
+++ b/backend/models.py
@@ -48,3 +48,12 @@ class Watchlist(Base):
     user_id:  Mapped[int | None] = mapped_column(Integer, ForeignKey("users.id"))
     ticker:   Mapped[str]        = mapped_column(String, nullable=False)
     added_at: Mapped[datetime]   = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+
+class MarketDataCache(Base):
+    __tablename__ = "market_data_cache"
+    id:         Mapped[int]      = mapped_column(Integer, primary_key=True, index=True)
+    ticker:     Mapped[str]      = mapped_column(String, nullable=False)
+    period:     Mapped[str]      = mapped_column(String, nullable=False)
+    data:       Mapped[dict]     = mapped_column(JSON, nullable=False)
+    fetched_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,6 @@ yfinance
 authlib
 httpx
 itsdangerous
+
+pytest
+freezegun

--- a/backend/test_cache.py
+++ b/backend/test_cache.py
@@ -1,0 +1,60 @@
+from datetime import datetime, timedelta
+from freezegun import freeze_time
+
+
+def test_get_data_caches_and_reuses(client, mock_yf_download):
+    r1 = client.get("/api/data/AAPL?period=1Y")
+    assert r1.status_code == 200
+    data1 = r1.json()
+    assert len(data1) > 0
+
+    r2 = client.get("/api/data/AAPL?period=1Y")
+    assert r2.status_code == 200
+    data2 = r2.json()
+
+    assert data1 == data2
+    assert mock_yf_download.call_count == 1
+
+
+def test_cache_expires_after_24h(client, mock_yf_download):
+    now = datetime(2025, 5, 7, 12, 0, 0)
+
+    with freeze_time(now):
+        r1 = client.get("/api/data/AAPL?period=1Y")
+        assert r1.status_code == 200
+
+    assert mock_yf_download.call_count == 1
+
+    with freeze_time(now + timedelta(hours=25)):
+        r2 = client.get("/api/data/AAPL?period=1Y")
+        assert r2.status_code == 200
+
+    assert mock_yf_download.call_count == 2
+
+
+def test_backtest_endpoint_uses_cache(client, mock_yf_download):
+    payload = {"ticker": "AAPL", "period": "1Y", "strategy": "rsi"}
+
+    r1 = client.post("/api/backtest", json=payload)
+    assert r1.status_code == 200
+
+    r2 = client.post("/api/backtest", json=payload)
+    assert r2.status_code == 200
+
+    assert mock_yf_download.call_count == 1
+    assert r1.json()["stats"] == r2.json()["stats"]
+
+
+def test_cache_hit_returns_identical_data(client, mock_yf_download):
+    r1 = client.get("/api/data/AAPL?period=1Y")
+    r2 = client.get("/api/data/AAPL?period=1Y")
+
+    data1 = r1.json()
+    data2 = r2.json()
+
+    assert len(data1) == len(data2)
+    for row1, row2 in zip(data1, data2):
+        assert row1["Time"] == row2["Time"]
+        assert row1["Close"] == row2["Close"]
+        assert row1["Open"] == row2["Open"]
+        assert row1["Volume"] == row2["Volume"]


### PR DESCRIPTION
## Summary
- Ajout d'un cache de 24h pour les données yfinance en base de données
- Évite les appels API répétés pour les mêmes données historiques

## Test plan
- [ ] Vérifier que le premier appel récupère les données depuis yfinance
- [ ] Vérifier que les appels suivants utilisent le cache
- [ ] Vérifier que le cache expire bien après 24h