### PR TITLE
fix: correction bugs cache, métriques Sharpe/Sortino et profit_factor

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from sqlalchemy.orm import Session
 from pydantic import BaseModel, Field
 from typing import Optional
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import yfinance as yf
 import pandas as pd
 from dotenv import load_dotenv
@@ -13,6 +13,7 @@ from database import Base, engine, get_db
 import models  # noqa: F401 — enregistre les tables SQLAlchemy avant create_all
 from models import Backtest
 from cache import get_cached_data, store_cached_data
+from data import TICKER_MAP
 
 import data
 from strategies import STRATEGIES_REGISTRY
@@ -45,8 +46,11 @@ app.include_router(auth_router, prefix="/api/auth")
 
 
 def fetch_market_data(ticker: str, period: str, db: Session | None = None) -> pd.DataFrame:
+    symbol = TICKER_MAP.get(ticker.lower(), ticker)
+    period_key = period.upper()
+
     if db is not None:
-        cached = get_cached_data(db, ticker, period.upper())
+        cached = get_cached_data(db, symbol, period_key)
         if cached is not None:
             df = pd.DataFrame(cached)
             df["Time"] = pd.to_datetime(df["Time"])
@@ -59,11 +63,11 @@ def fetch_market_data(ticker: str, period: str, db: Session | None = None) -> pd
         "1Y": timedelta(days=365),
         "5Y": timedelta(days=365 * 5),
     }
-    window   = windows.get(period.upper(), timedelta(days=365))
+    window   = windows.get(period_key, timedelta(days=365))
     end      = datetime.today()
     start    = end - window
 
-    df = yf.download(ticker, start=start, end=end, auto_adjust=True)
+    df = yf.download(symbol, start=start, end=end, auto_adjust=True)
 
     if df.empty:
         raise HTTPException(status_code=404, detail=f"Ticker '{ticker}' introuvable sur Yahoo Finance.")
@@ -73,8 +77,10 @@ def fetch_market_data(ticker: str, period: str, db: Session | None = None) -> pd
     df = df.sort_index()
 
     if db is not None:
-        records = df.reset_index().assign(Time=lambda x: x["Time"].astype(str)).to_dict(orient="records")
-        store_cached_data(db, ticker, period.upper(), records)
+        records = df.reset_index().to_dict(orient="records")
+        for r in records:
+            r["Time"] = r["Time"].strftime("%Y-%m-%d")
+        store_cached_data(db, symbol, period_key, records)
 
     return df
 
@@ -220,7 +226,7 @@ async def upload_backtest(request: Request):
     return {
         "metadata": {
             **metadata,
-            "created_at": datetime.utcnow().isoformat() + "Z",
+            "created_at": datetime.now(timezone.utc).isoformat(),
         },
         "trades": trades_with_pnl,
         "metrics": metrics,

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -27,12 +27,12 @@ def compute_metrics(trades: list[dict], capital_initial: float) -> dict:
     durations = _trade_durations(trades)
     avg_duration = sum(durations) / len(durations) if durations else 0
 
-    time_in_market = sum(durations) / total_days * 100 if total_days > 0 else 0
+    time_in_market = min(sum(durations) / total_days * 100, 100.0) if total_days > 0 else 0
 
-    daily_returns = _estimate_daily_returns(trades, total_days)
-    sharpe = _sharpe_ratio(daily_returns)
-    sortino = _sortino_ratio(daily_returns)
-    volatility = _annualized_volatility(daily_returns)
+    trades_per_year = n_trades / years if years > 0 else n_trades
+    sharpe = _sharpe_ratio_per_trade(pnl_pcts, trades_per_year)
+    sortino = _sortino_ratio_per_trade(pnl_pcts, trades_per_year)
+    volatility = _annualized_volatility_per_trade(pnl_pcts, trades_per_year)
 
     max_dd = _max_drawdown(pnl_pcts, capital_initial)
 
@@ -46,7 +46,7 @@ def compute_metrics(trades: list[dict], capital_initial: float) -> dict:
         "max_drawdown_pct": round(max_dd, 2),
         "win_rate_pct": round(len(wins) / n_trades * 100, 2) if n_trades else 0,
         "n_trades": n_trades,
-        "profit_factor": round(sum(wins) / abs(sum(losses)), 2) if losses and sum(losses) != 0 else float("inf") if wins else 0,
+        "profit_factor": round(sum(wins) / abs(sum(losses)), 2) if losses and sum(losses) != 0 else None if wins else 0,
         "avg_win_pct": round(sum(wins) / len(wins), 2) if wins else 0,
         "avg_loss_pct": round(sum(losses) / len(losses), 2) if losses else 0,
         "max_consecutive_losses": _max_consecutive_losses(pnl_pcts),
@@ -132,57 +132,36 @@ def _trade_durations(trades: list[dict]) -> list[int]:
     return durations
 
 
-def _estimate_daily_returns(trades: list[dict], total_days: int) -> list[float]:
-    if not trades or total_days <= 0:
-        return []
-    daily = [0.0] * total_days
-    first_entry = _parse_time(trades[0]["entry_time"])
-    for t in trades:
-        pnl = _compute_pnl_pct(t)
-        entry = _parse_time(t["entry_time"])
-        exit_ = _parse_time(t["exit_time"])
-        if not entry or not exit_:
-            continue
-        duration = (exit_ - entry).days
-        if duration <= 0:
-            continue
-        daily_pnl = pnl / duration
-        start_idx = (entry - first_entry).days
-        for d in range(duration):
-            idx = start_idx + d
-            if 0 <= idx < total_days:
-                daily[idx] = daily_pnl
-    return daily
-
-
-def _sharpe_ratio(daily_returns: list[float]) -> float:
-    if len(daily_returns) < 2:
+def _sharpe_ratio_per_trade(pnl_pcts: list[float], trades_per_year: float) -> float:
+    if len(pnl_pcts) < 2:
         return 0.0
-    mean = sum(daily_returns) / len(daily_returns)
-    variance = sum((r - mean) ** 2 for r in daily_returns) / (len(daily_returns) - 1)
+    mean = sum(pnl_pcts) / len(pnl_pcts)
+    variance = sum((r - mean) ** 2 for r in pnl_pcts) / (len(pnl_pcts) - 1)
     std = math.sqrt(variance)
     if std == 0:
         return 0.0
-    return mean / std * math.sqrt(252)
+    return (mean / std) * math.sqrt(trades_per_year)
 
 
-def _sortino_ratio(daily_returns: list[float]) -> float:
-    if len(daily_returns) < 2:
+def _sortino_ratio_per_trade(pnl_pcts: list[float], trades_per_year: float) -> float:
+    if len(pnl_pcts) < 2:
         return 0.0
-    mean = sum(daily_returns) / len(daily_returns)
-    downside = [min(r, 0) ** 2 for r in daily_returns]
-    downside_dev = math.sqrt(sum(downside) / len(downside))
+    mean = sum(pnl_pcts) / len(pnl_pcts)
+    downside = [r ** 2 for r in pnl_pcts if r < 0]
+    if not downside:
+        return 0.0
+    downside_dev = math.sqrt(sum(downside) / len(pnl_pcts))
     if downside_dev == 0:
         return 0.0
-    return mean / downside_dev * math.sqrt(252)
+    return (mean / downside_dev) * math.sqrt(trades_per_year)
 
 
-def _annualized_volatility(daily_returns: list[float]) -> float:
-    if len(daily_returns) < 2:
+def _annualized_volatility_per_trade(pnl_pcts: list[float], trades_per_year: float) -> float:
+    if len(pnl_pcts) < 2:
         return 0.0
-    mean = sum(daily_returns) / len(daily_returns)
-    variance = sum((r - mean) ** 2 for r in daily_returns) / (len(daily_returns) - 1)
-    return math.sqrt(variance) * math.sqrt(252)
+    mean = sum(pnl_pcts) / len(pnl_pcts)
+    variance = sum((r - mean) ** 2 for r in pnl_pcts) / (len(pnl_pcts) - 1)
+    return math.sqrt(variance) * math.sqrt(trades_per_year)
 
 
 def _max_drawdown(pnl_pcts: list[float], capital: float) -> float:

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Integer, String, DateTime, Float, JSON, ForeignKey
+from sqlalchemy import Integer, String, DateTime, Float, JSON, ForeignKey, UniqueConstraint, Index
 from sqlalchemy.orm import Mapped, mapped_column
 from datetime import datetime, timezone
 from database import Base
@@ -52,8 +52,12 @@ class Watchlist(Base):
 
 class MarketDataCache(Base):
     __tablename__ = "market_data_cache"
+    __table_args__ = (
+        UniqueConstraint("ticker", "period", name="uq_cache_ticker_period"),
+        Index("ix_cache_ticker_period", "ticker", "period"),
+    )
     id:         Mapped[int]      = mapped_column(Integer, primary_key=True, index=True)
     ticker:     Mapped[str]      = mapped_column(String, nullable=False)
     period:     Mapped[str]      = mapped_column(String, nullable=False)
-    data:       Mapped[dict]     = mapped_column(JSON, nullable=False)
+    data:       Mapped[list]     = mapped_column(JSON, nullable=False)
     fetched_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(timezone.utc))


### PR DESCRIPTION
## Summary
- **#56** — Appliquer TICKER_MAP dans fetch_market_data() pour que le cache soit réellement partagé entre GET /api/data et POST /api/backtest. Harmonisation du format Time (strftime).
- **#57** — Ajout UniqueConstraint + Index sur MarketDataCache(ticker, period) pour éviter les doublons en cas de requêtes concurrentes.
- **#58** — Sharpe et Sortino recalculés sur les rendements par trade avec annualisation sqrt(trades/an) au lieu de daily returns estimés linéairement (biais supprimé). time_in_market clippé à 100%.
- **#59** — profit_factor: float('inf') remplacé par None (sérialisable JSON).

Resolves #56, resolves #57, resolves #58, resolves #59

## Test plan
- [ ] Lancer GET /api/data/sp500 puis POST /api/backtest ticker:sp500 et vérifier qu'une seule ligne cache existe en BDD
- [ ] Vérifier que la contrainte d'unicité empêche les doublons dans market_data_cache
- [ ] POST /api/backtest/upload avec un JSON de trades et vérifier que Sharpe/Sortino ont des valeurs réalistes
- [ ] POST /api/backtest/upload avec uniquement des trades gagnants et vérifier que profit_factor retourne null (pas crash)