### PR TITLE
feat: mode débutant multi-indicateurs AND + pipeline unifié

### DIFF
--- a/backend/combinator.py
+++ b/backend/combinator.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pandas as pd
+
+
+def combine_indicators(
+    df: pd.DataFrame,
+    indicators: list[dict],
+    registry: dict,
+) -> pd.DataFrame:
+    signal_columns: list[pd.Series] = []
+    extra_columns: dict[str, pd.Series] = {}
+
+    for ind in indicators:
+        name = ind["name"]
+        params = ind.get("params", {})
+
+        cls = registry[name]
+        strategy = cls(**params)
+        df_ind = strategy.compute_signals(df)
+
+        sig = df_ind["signal"].rename(f"signal_{name}")
+        signal_columns.append(sig)
+
+        skip = {"signal", "Open", "High", "Low", "Close", "Volume"}
+        for col in df_ind.columns:
+            if col not in skip:
+                extra_columns[col] = df_ind[col]
+
+    combined = pd.concat(signal_columns, axis=1, join="inner")
+
+    all_long = (combined == 1).all(axis=1)
+    all_short = (combined == -1).all(axis=1)
+    signal = pd.Series(
+        np.where(all_long, 1, np.where(all_short, -1, 0)),
+        index=combined.index,
+        name="signal",
+    )
+
+    result = df.loc[combined.index, ["Close"]].copy()
+    result["signal"] = signal
+
+    for col_name, col_data in extra_columns.items():
+        result[col_name] = col_data.reindex(combined.index)
+
+    for sc in signal_columns:
+        result[sc.name] = sc.reindex(combined.index)
+
+    return result

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,10 +17,11 @@ from data import TICKER_MAP
 
 import data
 from strategies import STRATEGIES_REGISTRY
-from backtest import run_backtest
 from auth import router as auth_router
 from validator import validate_upload
 from metrics import compute_metrics, compute_pnl_for_trades, build_equity_curve
+from trade_generator import signals_to_trades
+from combinator import combine_indicators
 
 load_dotenv()
 
@@ -85,80 +86,116 @@ def fetch_market_data(ticker: str, period: str, db: Session | None = None) -> pd
     return df
 
 
+class IndicatorConfig(BaseModel):
+    name:   str  = Field(..., example="macd")
+    params: dict = Field(default_factory=dict)
+
+
 class BacktestRequest(BaseModel):
-    ticker:          str             = Field(...,  example="AAPL")
-    period:          str             = Field("1Y", example="1Y")
-    strategy:        str             = Field(...,  example="macd")
-    params:          dict            = Field(default_factory=dict)
-    capital_initial: Optional[float] = Field(None, example=10000)
-    stop_loss:       Optional[float] = Field(None, example=0.05)
-    user_id:         Optional[int]   = Field(None)
+    ticker:          str                       = Field(...,  example="AAPL")
+    period:          str                       = Field("1Y", example="1Y")
+    strategy:        Optional[str]             = Field(None, example="macd")
+    params:          dict                      = Field(default_factory=dict)
+    indicators:      Optional[list[IndicatorConfig]] = Field(None)
+    capital_initial: Optional[float]           = Field(None, example=10000)
+    stop_loss:       Optional[float]           = Field(None, example=0.05)
+    user_id:         Optional[int]             = Field(None)
 
 
 @app.post("/api/backtest")
 def lancer_backtest(request: BacktestRequest, db: Session = Depends(get_db)):
 
-    strategy_key = request.strategy.lower()
-    if strategy_key not in STRATEGIES_REGISTRY:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Stratégie '{request.strategy}' non trouvée. Disponibles : {list(STRATEGIES_REGISTRY.keys())}"
-        )
+    if request.indicators:
+        indicator_list = [{"name": i.name, "params": i.params} for i in request.indicators]
+    elif request.strategy:
+        indicator_list = [{"name": request.strategy.lower(), "params": request.params}]
+    else:
+        raise HTTPException(status_code=400, detail="Fournir 'indicators' ou 'strategy'.")
+
+    for ind in indicator_list:
+        if ind["name"] not in STRATEGIES_REGISTRY:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Indicateur '{ind['name']}' non trouvé. Disponibles : {list(STRATEGIES_REGISTRY.keys())}",
+            )
 
     df = fetch_market_data(request.ticker, request.period, db)
 
     if len(df) < 10:
         raise HTTPException(status_code=422, detail="Pas assez de données pour cette période.")
 
-    StrategyClass = STRATEGIES_REGISTRY[strategy_key]
     try:
-        strategy = StrategyClass(**request.params)
+        df_combined = combine_indicators(df, indicator_list, STRATEGIES_REGISTRY)
     except (TypeError, ValueError) as e:
         raise HTTPException(status_code=422, detail=f"Paramètres invalides : {e}")
 
-    df_signals = strategy.compute_signals(df)
-
-    if df_signals.empty:
+    if df_combined.empty:
         raise HTTPException(
             status_code=422,
-            detail=(
-                f"Pas assez de données ({len(df)} barres) pour calculer les indicateurs "
-                f"avec ces paramètres. Essayez une période plus longue ou réduisez la fenêtre lente."
-            ),
+            detail="Pas assez de données pour calculer les indicateurs. Essayez une période plus longue.",
         )
 
-    try:
-        results = run_backtest(df_signals)
-    except ValueError as e:
-        raise HTTPException(status_code=422, detail=str(e))
+    trades = signals_to_trades(df_combined)
+    capital = request.capital_initial or 10000
 
-    stats = results["stats"]
+    trades_with_pnl = compute_pnl_for_trades(trades)
+    metrics = compute_metrics(trades, capital)
 
-    # Sauvegarde en DB si l'utilisateur est connecté
+    first_close = float(df_combined["Close"].iloc[0])
+    last_close = float(df_combined["Close"].iloc[-1])
+    metrics["market_return_pct"] = round((last_close / first_close - 1) * 100, 2)
+
+    equity_curve = build_equity_curve(trades, capital)
+
+    for point in equity_curve:
+        date_str = point["time"]
+        matching = df_combined.index[df_combined.index.strftime("%Y-%m-%d") <= date_str]
+        if len(matching) > 0:
+            price_at_date = float(df_combined.loc[matching[-1], "Close"])
+            point["market"] = round(capital * (price_at_date / first_close), 2)
+
+    strategy_name = " + ".join(ind["name"] for ind in indicator_list)
+
+    _INTERNAL = {"Open", "High", "Low", "Volume", "Close"}
+    keep = [c for c in df_combined.columns if c not in _INTERNAL]
+    signals_df = df_combined.reset_index()[["Time"] + keep].copy()
+    signals_df["Time"] = signals_df["Time"].dt.strftime("%Y-%m-%d %H:%M:%S")
+    float_cols = signals_df.select_dtypes(include="float").columns
+    signals_df[float_cols] = signals_df[float_cols].round(4)
+    signals_list = signals_df.to_dict(orient="records")
+
     if request.user_id:
         record = Backtest(
             user_id              = request.user_id,
             ticker               = request.ticker,
-            strategy             = strategy_key,
+            strategy             = strategy_name,
             period               = request.period,
-            params               = request.params,
-            capital_initial      = request.capital_initial,
+            params               = request.params if len(indicator_list) == 1 else {"indicators": indicator_list},
+            capital_initial      = capital,
             stop_loss            = request.stop_loss,
-            total_return_strat   = stats["total_return_strat"],
-            total_return_market  = stats["total_return_market"],
-            sharpe_ratio         = stats["sharpe_ratio"],
-            max_drawdown         = stats["max_drawdown"],
-            n_trades             = stats["n_trades"],
-            win_rate             = stats["win_rate"],
+            total_return_strat   = metrics["total_return_pct"] / 100,
+            total_return_market  = (metrics["market_return_pct"] or 0) / 100,
+            sharpe_ratio         = metrics["sharpe_ratio"],
+            max_drawdown         = metrics["max_drawdown_pct"] / 100,
+            n_trades             = metrics["n_trades"],
+            win_rate             = metrics["win_rate_pct"] / 100,
         )
         db.add(record)
         db.commit()
 
     return {
-        "ticker":   request.ticker,
-        "strategy": strategy_key,
-        "params":   request.params,
-        **results,
+        "metadata": {
+            "ticker": request.ticker,
+            "period": request.period,
+            "capital_initial": capital,
+            "strategy": strategy_name,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+        "trades": trades_with_pnl,
+        "metrics": metrics,
+        "equity_curve": equity_curve,
+        "custom_series": [],
+        "signals": signals_list,
     }
 
 
@@ -201,7 +238,16 @@ def delete_backtest(backtest_id: int, db: Session = Depends(get_db)):
 
 @app.get("/api/strategies")
 def list_strategies():
-    return {"strategies": list(STRATEGIES_REGISTRY.keys())}
+    result = []
+    for key, cls in STRATEGIES_REGISTRY.items():
+        instance = cls()
+        result.append({
+            "name": key,
+            "description": instance.description,
+            "category": instance.category,
+            "default_params": instance.default_params,
+        })
+    return {"strategies": result}
 
 
 @app.post("/api/backtest/upload")

--- a/backend/strategies/base.py
+++ b/backend/strategies/base.py
@@ -36,3 +36,15 @@ class BaseStrategy(ABC):
     def name(self) -> str:
         """Nom court de la stratégie (ex: 'macd', 'rsi', 'ma_crossover')."""
         ...
+
+    @property
+    @abstractmethod
+    def description(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def category(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def default_params(self) -> dict[str, float]: ...

--- a/backend/strategies/ma_crossover.py
+++ b/backend/strategies/ma_crossover.py
@@ -27,6 +27,18 @@ class MACrossoverStrategy(BaseStrategy):
     def name(self) -> str:
         return "ma_crossover"
 
+    @property
+    def description(self) -> str:
+        return "Croisement de moyennes mobiles simple. Signal haussier quand la moyenne rapide passe au-dessus de la lente."
+
+    @property
+    def category(self) -> str:
+        return "trend"
+
+    @property
+    def default_params(self) -> dict[str, float]:
+        return {"fast": 10, "slow": 30}
+
     def compute_signals(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.copy()
 

--- a/backend/strategies/macd.py
+++ b/backend/strategies/macd.py
@@ -27,6 +27,18 @@ class MACDStrategy(BaseStrategy):
     def name(self) -> str:
         return "macd"
 
+    @property
+    def description(self) -> str:
+        return "Mesure la convergence/divergence des moyennes mobiles. Signal haussier quand la ligne MACD croise au-dessus de la ligne signal."
+
+    @property
+    def category(self) -> str:
+        return "momentum"
+
+    @property
+    def default_params(self) -> dict[str, float]:
+        return {"fast": 12, "slow": 26, "signal": 9}
+
     def compute_signals(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.copy()
 

--- a/backend/strategies/rsi.py
+++ b/backend/strategies/rsi.py
@@ -28,6 +28,18 @@ class RSIStrategy(BaseStrategy):
     def name(self) -> str:
         return "rsi"
 
+    @property
+    def description(self) -> str:
+        return "Mesure la vitesse des mouvements de prix. Identifie les zones de surachat (>70) et survente (<30)."
+
+    @property
+    def category(self) -> str:
+        return "momentum"
+
+    @property
+    def default_params(self) -> dict[str, float]:
+        return {"length": 14, "overbought": 70, "oversold": 30}
+
     def compute_signals(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.copy()
 

--- a/backend/test_combinator.py
+++ b/backend/test_combinator.py
@@ -1,0 +1,73 @@
+import pandas as pd
+import numpy as np
+from combinator import combine_indicators
+from strategies import STRATEGIES_REGISTRY
+
+
+def _make_ohlcv(n: int = 100) -> pd.DataFrame:
+    np.random.seed(42)
+    dates = pd.date_range("2024-01-01", periods=n, freq="B", name="Time")
+    close = 100 + np.cumsum(np.random.randn(n) * 0.5)
+    return pd.DataFrame({
+        "Open": close - 0.2,
+        "High": close + 0.5,
+        "Low": close - 0.5,
+        "Close": close,
+        "Volume": np.random.randint(1000, 10000, n),
+    }, index=dates)
+
+
+def test_single_indicator():
+    df = _make_ohlcv()
+    indicators = [{"name": "macd", "params": {}}]
+    result = combine_indicators(df, indicators, STRATEGIES_REGISTRY)
+    assert "signal" in result.columns
+    assert set(result["signal"].unique()).issubset({-1, 0, 1})
+
+
+def test_two_indicators_and_logic():
+    df = _make_ohlcv(200)
+    indicators = [
+        {"name": "macd", "params": {}},
+        {"name": "rsi", "params": {}},
+    ]
+    result = combine_indicators(df, indicators, STRATEGIES_REGISTRY)
+    assert "signal" in result.columns
+    assert "signal_macd" in result.columns
+    assert "signal_rsi" in result.columns
+
+    for _, row in result.iterrows():
+        if row["signal"] == 1:
+            assert row["signal_macd"] == 1 and row["signal_rsi"] == 1
+        elif row["signal"] == -1:
+            assert row["signal_macd"] == -1 and row["signal_rsi"] == -1
+
+
+def test_three_indicators():
+    df = _make_ohlcv(200)
+    indicators = [
+        {"name": "macd", "params": {}},
+        {"name": "rsi", "params": {}},
+        {"name": "ma_crossover", "params": {"fast": 10, "slow": 30}},
+    ]
+    result = combine_indicators(df, indicators, STRATEGIES_REGISTRY)
+    assert "signal" in result.columns
+    assert "signal_ma_crossover" in result.columns
+
+
+def test_preserves_indicator_columns():
+    df = _make_ohlcv()
+    indicators = [{"name": "rsi", "params": {}}]
+    result = combine_indicators(df, indicators, STRATEGIES_REGISTRY)
+    assert "rsi" in result.columns
+
+
+def test_index_alignment():
+    df = _make_ohlcv(200)
+    indicators = [
+        {"name": "ma_crossover", "params": {"fast": 5, "slow": 50}},
+        {"name": "ma_crossover", "params": {"fast": 10, "slow": 30}},
+    ]
+    result = combine_indicators(df, indicators, STRATEGIES_REGISTRY)
+    assert not result.empty
+    assert not result["signal"].isna().any()

--- a/backend/test_trade_generator.py
+++ b/backend/test_trade_generator.py
@@ -1,0 +1,75 @@
+import pandas as pd
+import numpy as np
+from trade_generator import signals_to_trades
+
+
+def _make_df(signals: list[int], prices: list[float] | None = None) -> pd.DataFrame:
+    n = len(signals)
+    if prices is None:
+        prices = [100.0 + i for i in range(n)]
+    dates = pd.date_range("2025-01-01", periods=n, freq="B", name="Time")
+    return pd.DataFrame({"Close": prices, "signal": signals}, index=dates)
+
+
+def test_single_long_trade():
+    df = _make_df([0, 1, 1, 1, 0])
+    trades = signals_to_trades(df)
+    assert len(trades) == 1
+    assert trades[0]["direction"] == "long"
+    assert trades[0]["entry_price"] == 101.0
+    assert trades[0]["exit_price"] == 104.0
+
+
+def test_single_short_trade():
+    df = _make_df([0, -1, -1, 0])
+    trades = signals_to_trades(df)
+    assert len(trades) == 1
+    assert trades[0]["direction"] == "short"
+
+
+def test_flip_long_to_short():
+    df = _make_df([1, 1, -1, -1, 0])
+    trades = signals_to_trades(df)
+    assert len(trades) == 2
+    assert trades[0]["direction"] == "long"
+    assert trades[1]["direction"] == "short"
+    assert trades[0]["exit_price"] == trades[1]["entry_price"]
+
+
+def test_auto_close_at_end():
+    df = _make_df([0, 1, 1, 1])
+    trades = signals_to_trades(df)
+    assert len(trades) == 1
+    assert trades[0]["exit_price"] == 103.0
+
+
+def test_no_signals():
+    df = _make_df([0, 0, 0, 0])
+    trades = signals_to_trades(df)
+    assert len(trades) == 0
+
+
+def test_all_long():
+    df = _make_df([1, 1, 1, 1])
+    trades = signals_to_trades(df)
+    assert len(trades) == 1
+    assert trades[0]["direction"] == "long"
+
+
+def test_alternating_signals():
+    df = _make_df([1, -1, 1, -1, 0])
+    trades = signals_to_trades(df)
+    assert len(trades) == 4
+    assert trades[0]["direction"] == "long"
+    assert trades[1]["direction"] == "short"
+    assert trades[2]["direction"] == "long"
+    assert trades[3]["direction"] == "short"
+
+
+def test_neutral_gap_between_trades():
+    df = _make_df([1, 1, 0, 0, -1, -1, 0])
+    trades = signals_to_trades(df)
+    assert len(trades) == 2
+    assert trades[0]["direction"] == "long"
+    assert trades[1]["direction"] == "short"
+    assert trades[0]["exit_price"] != trades[1]["entry_price"]

--- a/backend/trade_generator.py
+++ b/backend/trade_generator.py
@@ -1,0 +1,45 @@
+import pandas as pd
+
+
+def signals_to_trades(df: pd.DataFrame) -> list[dict]:
+    trades: list[dict] = []
+    current_dir: str | None = None
+    entry_time = None
+    entry_price = 0.0
+
+    for time, row in df.iterrows():
+        sig = int(row["signal"])
+        close = float(row["Close"])
+        new_dir = {1: "long", -1: "short"}.get(sig)
+
+        if new_dir == current_dir:
+            continue
+
+        if current_dir is not None:
+            trades.append({
+                "entry_time": entry_time,
+                "exit_time": time.strftime("%Y-%m-%d"),
+                "direction": current_dir,
+                "entry_price": entry_price,
+                "exit_price": close,
+            })
+
+        if new_dir is not None:
+            entry_time = time.strftime("%Y-%m-%d")
+            entry_price = close
+            current_dir = new_dir
+        else:
+            current_dir = None
+
+    if current_dir is not None:
+        last_time = df.index[-1]
+        last_close = float(df["Close"].iloc[-1])
+        trades.append({
+            "entry_time": entry_time,
+            "exit_time": last_time.strftime("%Y-%m-%d"),
+            "direction": current_dir,
+            "entry_price": entry_price,
+            "exit_price": last_close,
+        })
+
+    return trades

--- a/frontend/src/app/pages/backtests/backtests.html
+++ b/frontend/src/app/pages/backtests/backtests.html
@@ -19,28 +19,63 @@
       <mat-option value="5Y">5 Ans</mat-option>
     </mat-select>
   </mat-form-field>
+</div>
 
-  <mat-form-field>
-    <mat-label>Stratégie</mat-label>
-    <mat-select [value]="strategy()" (selectionChange)="onStrategyChange($event.value)">
-      <mat-option value="macd">MACD</mat-option>
-      <mat-option value="rsi">RSI</mat-option>
-      <mat-option value="ma_crossover">MA Crossover</mat-option>
+<!-- ── Indicateurs sélectionnés ────────────────────────────────────────── -->
+<h2>Indicateurs</h2>
+
+@for (indicator of selectedIndicators(); track $index; let i = $index) {
+  <mat-card class="indicator-card">
+    <mat-card-content>
+      <div class="indicator-header">
+        <div>
+          <span class="indicator-name">{{ indicator.name.toUpperCase() }}</span>
+          @if (getStrategyInfo(indicator.name); as info) {
+            <span class="indicator-category">{{ info.category }}</span>
+            <p class="indicator-description">{{ info.description }}</p>
+          }
+        </div>
+        @if (selectedIndicators().length > 1) {
+          <button mat-icon-button (click)="removeIndicator(i)" aria-label="Supprimer">
+            <mat-icon>close</mat-icon>
+          </button>
+        }
+      </div>
+
+      <div class="params-row">
+        @for (key of getParamKeys(i); track key) {
+          <mat-form-field class="param-field">
+            <mat-label>{{ key }}</mat-label>
+            <input matInput type="number"
+                   [value]="indicator.params[key]"
+                   (change)="updateIndicatorParam(i, key, $any($event.target).value)" />
+          </mat-form-field>
+        }
+      </div>
+    </mat-card-content>
+  </mat-card>
+}
+
+<!-- ── Ajouter un indicateur ───────────────────────────────────────────── -->
+@if (availableIndicators().length > 0) {
+  <mat-form-field class="add-indicator">
+    <mat-label>Ajouter un indicateur</mat-label>
+    <mat-select (selectionChange)="addIndicator($event.value); $any($event.source).value = null">
+      @for (strat of availableIndicators(); track strat.name) {
+        <mat-option [value]="strat.name">
+          {{ strat.name.toUpperCase() }} — {{ strat.description }}
+        </mat-option>
+      }
     </mat-select>
   </mat-form-field>
-</div>
+}
 
-<!-- ── Paramètres dynamiques ──────────────────────────────────────────── -->
-<div class="form-row params-row">
-  @for (key of paramKeys(); track key) {
-    <mat-form-field class="param-field">
-      <mat-label>{{ key }}</mat-label>
-      <input matInput type="number"
-             [value]="params()[key]"
-             (change)="updateParam(key, $any($event.target).value)" />
-    </mat-form-field>
-  }
-</div>
+@if (selectedIndicators().length > 1) {
+  <p class="and-hint">
+    <mat-icon>info</mat-icon>
+    Les indicateurs sont combinés en logique AND : le signal n'est actif que si tous les indicateurs sont d'accord.
+  </p>
+}
 
 <button mat-raised-button color="primary" (click)="runBacktest()" [disabled]="isLoading()">
   <mat-icon>play_arrow</mat-icon> Lancer le backtest
@@ -56,77 +91,4 @@
 
 @if (errorMessage()) {
   <p class="error"><mat-icon>error</mat-icon> {{ errorMessage() }}</p>
-}
-
-<!-- ── Résultats ──────────────────────────────────────────────────────── -->
-@if (result(); as res) {
-  <div class="results">
-
-    <!-- Stats cards -->
-    <div class="stats-grid">
-      <mat-card>
-        <mat-card-content>
-          <div class="stat-label">Rendement stratégie</div>
-          <div class="stat-value" [class.positive]="res.stats.total_return_strat > 0"
-                                  [class.negative]="res.stats.total_return_strat < 0">
-            {{ pct(res.stats.total_return_strat) }}
-          </div>
-        </mat-card-content>
-      </mat-card>
-
-      <mat-card>
-        <mat-card-content>
-          <div class="stat-label">Rendement marché</div>
-          <div class="stat-value" [class.positive]="res.stats.total_return_market > 0"
-                                  [class.negative]="res.stats.total_return_market < 0">
-            {{ pct(res.stats.total_return_market) }}
-          </div>
-        </mat-card-content>
-      </mat-card>
-
-      <mat-card>
-        <mat-card-content>
-          <div class="stat-label">Ratio de Sharpe</div>
-          <div class="stat-value">{{ res.stats.sharpe_ratio }}</div>
-        </mat-card-content>
-      </mat-card>
-
-      <mat-card>
-        <mat-card-content>
-          <div class="stat-label">Drawdown max</div>
-          <div class="stat-value negative">{{ pct(res.stats.max_drawdown) }}</div>
-        </mat-card-content>
-      </mat-card>
-
-      <mat-card>
-        <mat-card-content>
-          <div class="stat-label">Trades</div>
-          <div class="stat-value">{{ res.stats.n_trades }}</div>
-        </mat-card-content>
-      </mat-card>
-
-      <mat-card>
-        <mat-card-content>
-          <div class="stat-label">Win rate</div>
-          <div class="stat-value">{{ pct(res.stats.win_rate) }}</div>
-        </mat-card-content>
-      </mat-card>
-    </div>
-
-    <!-- Courbe d'équité -->
-    <mat-card class="chart-card">
-      <mat-card-header>
-        <mat-card-title>Courbe d'équité</mat-card-title>
-        <mat-card-subtitle>
-          <span class="legend-strat">— Stratégie</span>
-          &nbsp;&nbsp;
-          <span class="legend-market">— Marché (buy &amp; hold)</span>
-        </mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <div [innerHTML]="equitySvg()"></div>
-      </mat-card-content>
-    </mat-card>
-
-  </div>
 }

--- a/frontend/src/app/pages/backtests/backtests.scss
+++ b/frontend/src/app/pages/backtests/backtests.scss
@@ -1,0 +1,100 @@
+:host {
+  display: block;
+  padding: 24px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+h1 { margin: 0 0 4px; font-size: 1.6rem; }
+h2 { margin: 24px 0 12px; font-size: 1.1rem; color: #ccc; }
+
+.form-row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.indicator-card {
+  margin-bottom: 12px;
+
+  .indicator-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+
+  .indicator-name {
+    font-weight: 600;
+    font-size: 1rem;
+    color: #4fc3f7;
+  }
+
+  .indicator-category {
+    margin-left: 8px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #888;
+    background: #2a2a2a;
+    padding: 2px 8px;
+    border-radius: 4px;
+  }
+
+  .indicator-description {
+    margin: 6px 0 12px;
+    font-size: 0.85rem;
+    color: #aaa;
+    line-height: 1.4;
+  }
+
+  .params-row {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .param-field {
+    width: 120px;
+  }
+}
+
+.add-indicator {
+  width: 100%;
+  margin-bottom: 16px;
+}
+
+.and-hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #888;
+  font-size: 0.85rem;
+  margin: 8px 0 16px;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+button[mat-raised-button] {
+  margin-bottom: 20px;
+}
+
+.center-status {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 16px 0;
+  color: #aaa;
+}
+
+.error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #ef5350;
+  margin: 16px 0;
+}

--- a/frontend/src/app/pages/backtests/backtests.ts
+++ b/frontend/src/app/pages/backtests/backtests.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -8,7 +8,13 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { DataService, BacktestResult, normalizeOldResult } from '../../../services/data-service';
+import { MatChipsModule } from '@angular/material/chips';
+import {
+  DataService,
+  IndicatorConfig,
+  StrategyInfo,
+  normalizeUploadResult,
+} from '../../../services/data-service';
 import { AuthService } from '../../../services/auth.service';
 import { BacktestHistoryService } from '../../../services/backtest-history.service';
 
@@ -16,12 +22,6 @@ const TICKER_MAP: Record<string, string> = {
   sp500:  '^GSPC',
   nasdaq: '^IXIC',
   nq:     'NQ=F',
-};
-
-const DEFAULT_PARAMS: Record<string, Record<string, number>> = {
-  macd:         { fast: 12, slow: 26, signal: 9 },
-  rsi:          { length: 14, overbought: 70, oversold: 30 },
-  ma_crossover: { fast: 10, slow: 30 },
 };
 
 @Component({
@@ -35,11 +35,12 @@ const DEFAULT_PARAMS: Record<string, Record<string, number>> = {
     MatCardModule,
     MatIconModule,
     MatProgressSpinnerModule,
+    MatChipsModule,
   ],
   templateUrl: './backtests.html',
   styleUrl: './backtests.scss',
 })
-export class Backtests {
+export class Backtests implements OnInit {
   private dataService = inject(DataService);
   private auth        = inject(AuthService);
   private router      = inject(Router);
@@ -47,43 +48,70 @@ export class Backtests {
 
   ticker   = signal<string>('sp500');
   period   = signal<string>('1Y');
-  strategy = signal<string>('macd');
 
-  params = signal<Record<string, number>>({ ...DEFAULT_PARAMS['macd'] });
+  availableStrategies = signal<StrategyInfo[]>([]);
+  selectedIndicators  = signal<IndicatorConfig[]>([]);
 
   isLoading    = signal<boolean>(false);
   errorMessage = signal<string | null>(null);
-  result       = signal<BacktestResult | null>(null);
 
-  onStrategyChange(value: string) {
-    this.strategy.set(value);
-    this.params.set({ ...DEFAULT_PARAMS[value] });
+  availableIndicators = computed(() => {
+    const selected = new Set(this.selectedIndicators().map(i => i.name));
+    return this.availableStrategies().filter(s => !selected.has(s.name));
+  });
+
+  ngOnInit() {
+    this.dataService.getStrategies().subscribe(res => {
+      this.availableStrategies.set(res.strategies);
+      if (this.selectedIndicators().length === 0 && res.strategies.length > 0) {
+        const first = res.strategies[0];
+        this.selectedIndicators.set([{ name: first.name, params: { ...first.default_params } }]);
+      }
+    });
   }
 
-  paramKeys(): string[] {
-    return Object.keys(this.params());
+  getStrategyInfo(name: string): StrategyInfo | undefined {
+    return this.availableStrategies().find(s => s.name === name);
   }
 
-  updateParam(key: string, value: string) {
-    this.params.update(p => ({ ...p, [key]: parseFloat(value) }));
+  addIndicator(name: string) {
+    const info = this.getStrategyInfo(name);
+    if (!info) return;
+    this.selectedIndicators.update(list => [
+      ...list,
+      { name: info.name, params: { ...info.default_params } },
+    ]);
+  }
+
+  removeIndicator(index: number) {
+    this.selectedIndicators.update(list => list.filter((_, i) => i !== index));
+  }
+
+  getParamKeys(index: number): string[] {
+    return Object.keys(this.selectedIndicators()[index].params);
+  }
+
+  updateIndicatorParam(index: number, key: string, value: string) {
+    this.selectedIndicators.update(list =>
+      list.map((ind, i) =>
+        i === index ? { ...ind, params: { ...ind.params, [key]: parseFloat(value) } } : ind
+      )
+    );
   }
 
   runBacktest() {
     this.isLoading.set(true);
     this.errorMessage.set(null);
-    this.result.set(null);
 
     this.dataService.runBacktest({
-      ticker:   TICKER_MAP[this.ticker()] ?? this.ticker(),
-      period:   this.period(),
-      strategy: this.strategy(),
-      params:   this.params(),
-      user_id:  this.auth.getUser()?.id,
+      ticker:     TICKER_MAP[this.ticker()] ?? this.ticker(),
+      period:     this.period(),
+      indicators: this.selectedIndicators(),
+      user_id:    this.auth.getUser()?.id,
     }).subscribe({
       next: (data) => {
-        const normalized = normalizeOldResult(data);
+        const normalized = normalizeUploadResult(data, 'beginner', data.signals ?? []);
         this.historyService.push(normalized);
-        this.result.set(data);
         this.isLoading.set(false);
         this.router.navigate(['/results'], { state: { result: normalized } });
       },
@@ -93,36 +121,5 @@ export class Backtests {
         this.isLoading.set(false);
       },
     });
-  }
-
-  pct(value: number): string {
-    return (value * 100).toFixed(2) + '%';
-  }
-
-  equitySvg(): string {
-    const curve = this.result()?.equity_curve;
-    if (!curve || curve.length === 0) return '';
-
-    const w = 800, h = 200, pad = 10;
-    const stratVals  = curve.map(p => p.cumulative_strat);
-    const marketVals = curve.map(p => p.cumulative_market);
-    const allVals    = [...stratVals, ...marketVals];
-    const minV = Math.min(...allVals);
-    const maxV = Math.max(...allVals);
-    const range = maxV - minV || 1;
-
-    const toX = (i: number) => pad + (i / (curve.length - 1)) * (w - 2 * pad);
-    const toY = (v: number) => h - pad - ((v - minV) / range) * (h - 2 * pad);
-
-    const toPath = (vals: number[]) =>
-      vals.map((v, i) => `${i === 0 ? 'M' : 'L'}${toX(i).toFixed(1)},${toY(v).toFixed(1)}`).join(' ');
-
-    return `
-      <svg viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg" style="width:100%;height:200px">
-        <line x1="${pad}" y1="${toY(0).toFixed(1)}" x2="${w - pad}" y2="${toY(0).toFixed(1)}"
-              stroke="#555" stroke-width="1" stroke-dasharray="4,4"/>
-        <path d="${toPath(marketVals)}" fill="none" stroke="#888" stroke-width="2"/>
-        <path d="${toPath(stratVals)}"  fill="none" stroke="#4fc3f7" stroke-width="2.5"/>
-      </svg>`;
   }
 }

--- a/frontend/src/services/data-service.ts
+++ b/frontend/src/services/data-service.ts
@@ -13,11 +13,24 @@ export interface MarketData {
   Volume: number;
 }
 
+export interface IndicatorConfig {
+  name: string;
+  params: Record<string, number>;
+}
+
+export interface StrategyInfo {
+  name: string;
+  description: string;
+  category: string;
+  default_params: Record<string, number>;
+}
+
 export interface BacktestRequest {
   ticker: string;
   period: string;
-  strategy: string;
-  params: Record<string, number>;
+  strategy?: string;
+  params?: Record<string, number>;
+  indicators?: IndicatorConfig[];
   capital_initial?: number;
   stop_loss?: number;
   user_id?: number;
@@ -197,16 +210,20 @@ export function normalizeOldResult(old: BacktestResult): NormalizedResult {
   };
 }
 
-export function normalizeUploadResult(upload: UploadBacktestResult): NormalizedResult {
+export function normalizeUploadResult(
+  upload: UploadBacktestResult,
+  source: 'beginner' | 'advanced' = 'advanced',
+  signals: Record<string, number | string>[] = [],
+): NormalizedResult {
   return {
-    source: 'advanced',
+    source,
     ticker: upload.metadata.ticker,
     strategy: upload.metadata.strategy,
     metrics: upload.metrics,
     equity_curve: upload.equity_curve,
     trades: upload.trades,
     custom_series: upload.custom_series,
-    signals: [],
+    signals,
   };
 }
 
@@ -221,8 +238,12 @@ export class DataService {
     return this.http.get<MarketData[]>(`${this.api}/api/data/${ticker}?period=${period}`);
   }
 
-  runBacktest(request: BacktestRequest): Observable<BacktestResult> {
-    return this.http.post<BacktestResult>(`${this.api}/api/backtest`, request);
+  runBacktest(request: BacktestRequest): Observable<UploadBacktestResult & { signals?: Record<string, number | string>[] }> {
+    return this.http.post<UploadBacktestResult & { signals?: Record<string, number | string>[] }>(`${this.api}/api/backtest`, request);
+  }
+
+  getStrategies(): Observable<{ strategies: StrategyInfo[] }> {
+    return this.http.get<{ strategies: StrategyInfo[] }>(`${this.api}/api/strategies`);
   }
 
   uploadBacktest(data: object): Observable<UploadBacktestResult> {


### PR DESCRIPTION
## Summary

- Ajout d'un **générateur de trades** : convertit les signaux bar-par-bar en objets trade (entrée, sortie, direction, prix), avec gestion du flip long↔short et auto-close en fin de données
- Ajout d'un **combinateur AND** : combine N indicateurs — signal +1 seulement si tous donnent +1, -1 seulement si tous donnent -1, 0 sinon
- **`POST /api/backtest`** accepte maintenant une liste `indicators` et retourne le **format unifié** (16 métriques, trades, equity curve, custom_series) — même format que le mode avancé
- **`GET /api/strategies`** enrichi avec description, catégorie et paramètres par défaut pour chaque indicateur
- **Frontend** : sélection multiple d'indicateurs avec descriptions intuitives, paramètres configurables par indicateur, hint logique AND
- **13 tests unitaires** pour le trade generator et le combinator

## Test plan

- [ ] `POST /api/backtest` avec un seul indicateur → format unifié avec trades + 16 métriques
- [ ] `POST /api/backtest` avec `indicators: [{name: "macd"}, {name: "rsi"}]` → combinaison AND
- [ ] `GET /api/strategies` → retourne 3 objets avec description/category/default_params
- [ ] Page backtests : sélectionner un indicateur, lancer, vérifier résultats sur /results
- [ ] Page backtests : ajouter un second indicateur, lancer, vérifier que la combinaison AND fonctionne
- [ ] Backward compat : l'ancien format `{strategy: "macd", params: {...}}` fonctionne toujours
- [ ] `pytest backend/test_trade_generator.py backend/test_combinator.py` — 13/13 passent

Closes #49