### PR TITLE
feat: settings UX — dark mode, notifications, UI polish

### DIFF
--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Navbar } from './components/navbar/navbar';
 
 @Component({
@@ -7,4 +7,9 @@ import { Navbar } from './components/navbar/navbar';
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })
-export class App {}
+export class App implements OnInit {
+  ngOnInit() {
+    const saved = localStorage.getItem('theme');
+    document.body.classList.toggle('dark-theme', saved === 'dark');
+  }
+}

--- a/frontend/src/app/components/navbar/navbar.html
+++ b/frontend/src/app/components/navbar/navbar.html
@@ -48,6 +48,41 @@
       }
       <span class="spacer"></span>
 
+      <!-- Cloche notifications -->
+      <button mat-icon-button [matMenuTriggerFor]="notifMenu" matTooltip="Notifications"
+              (menuOpened)="notifService.markAllRead()">
+        <mat-icon
+          [matBadge]="notifService.unreadCount() || null"
+          matBadgeColor="warn"
+          matBadgeSize="small">
+          notifications
+        </mat-icon>
+      </button>
+
+      <mat-menu #notifMenu="matMenu" class="notif-menu">
+        <div class="notif-header" (click)="$event.stopPropagation()">
+          <span>Notifications</span>
+          @if (notifService.notifications().length) {
+            <button mat-button color="warn" (click)="notifService.clear()">Tout effacer</button>
+          }
+        </div>
+        <mat-divider />
+        @if (notifService.notifications().length === 0) {
+          <div class="notif-empty">Aucune notification</div>
+        }
+        @for (n of notifService.notifications(); track n.id) {
+          <div class="notif-item notif-{{ n.type }}" (click)="$event.stopPropagation()">
+            <mat-icon class="notif-icon">
+              {{ n.type === 'success' ? 'check_circle' : n.type === 'error' ? 'error' : 'info' }}
+            </mat-icon>
+            <div class="notif-body">
+              <span class="notif-msg">{{ n.message }}</span>
+              <span class="notif-time">{{ n.timestamp | date:'HH:mm' }}</span>
+            </div>
+          </div>
+        }
+      </mat-menu>
+
       @if (isDemo()) {
         <span class="demo-badge">Mode démo</span>
         <button mat-stroked-button (click)="logout()">Se connecter</button>

--- a/frontend/src/app/components/navbar/navbar.scss
+++ b/frontend/src/app/components/navbar/navbar.scss
@@ -81,6 +81,64 @@
     display: none;
   }
 }
+// ─── Notifications ────────────────────────────────────────────────────────────
+
+.notif-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px 4px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  min-width: 300px;
+}
+
+.notif-empty {
+  padding: 20px 16px;
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.875rem;
+  text-align: center;
+}
+
+.notif-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 16px;
+  border-left: 3px solid transparent;
+  cursor: default;
+
+  &.notif-success { border-left-color: #4caf50; .notif-icon { color: #4caf50; } }
+  &.notif-error   { border-left-color: var(--mat-sys-error); .notif-icon { color: var(--mat-sys-error); } }
+  &.notif-info    { border-left-color: var(--mat-sys-primary); .notif-icon { color: var(--mat-sys-primary); } }
+}
+
+.notif-icon {
+  font-size: 20px;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.notif-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.notif-msg {
+  font-size: 0.875rem;
+  line-height: 1.3;
+}
+
+.notif-time {
+  font-size: 0.75rem;
+  color: var(--mat-sys-on-surface-variant);
+}
+
+// ─── App title ────────────────────────────────────────────────────────────────
+
 .app-title {
     cursor: pointer;
 	display: inline-flex;

--- a/frontend/src/app/components/navbar/navbar.ts
+++ b/frontend/src/app/components/navbar/navbar.ts
@@ -8,13 +8,18 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatBadgeModule } from '@angular/material/badge';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { DatePipe } from '@angular/common';
 import { AuthService, UserInfo } from '../../../services/auth.service';
+import { NotificationService } from '../../../services/notification.service';
 
 @Component({
   selector: 'app-navbar',
   imports: [
     MatSidenavModule, MatToolbarModule, MatListModule,
     MatIconModule, MatButtonModule, MatMenuModule, MatDividerModule,
+    MatBadgeModule, MatTooltipModule, DatePipe,
     RouterLink, RouterOutlet,
   ],
   templateUrl: './navbar.html',
@@ -24,6 +29,7 @@ export class Navbar implements OnInit {
   private auth = inject(AuthService);
   private router = inject(Router);
   private breakpoints = inject(BreakpointObserver);
+  notifService = inject(NotificationService);
 
   @ViewChild('sidenav') sidenav!: MatSidenav;
 

--- a/frontend/src/app/pages/backtests/backtests.ts
+++ b/frontend/src/app/pages/backtests/backtests.ts
@@ -11,6 +11,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { DataService, BacktestResult, normalizeOldResult } from '../../../services/data-service';
 import { AuthService } from '../../../services/auth.service';
 import { BacktestHistoryService } from '../../../services/backtest-history.service';
+import { NotificationService } from '../../../services/notification.service';
 
 const TICKER_MAP: Record<string, string> = {
   sp500:  '^GSPC',
@@ -44,6 +45,7 @@ export class Backtests {
   private auth        = inject(AuthService);
   private router      = inject(Router);
   private historyService = inject(BacktestHistoryService);
+  private notifService = inject(NotificationService);
 
   ticker   = signal<string>('sp500');
   period   = signal<string>('1Y');
@@ -85,12 +87,14 @@ export class Backtests {
         this.historyService.push(normalized);
         this.result.set(data);
         this.isLoading.set(false);
+        this.notifService.push(`Backtest ${this.strategy().toUpperCase()} sur ${this.ticker()} terminé`, 'success');
         this.router.navigate(['/results'], { state: { result: normalized } });
       },
       error: (err) => {
         const detail = err?.error?.detail ?? 'Impossible de joindre le serveur.';
         this.errorMessage.set(detail);
         this.isLoading.set(false);
+        this.notifService.push(`Échec du backtest : ${detail}`, 'error');
       },
     });
   }

--- a/frontend/src/app/pages/settings/settings.html
+++ b/frontend/src/app/pages/settings/settings.html
@@ -60,8 +60,19 @@
               <mat-form-field class="full-width" appearance="outline">
                 <mat-label>Adresse email</mat-label>
                 <mat-icon matPrefix>email</mat-icon>
-                <input matInput type="email" [(ngModel)]="model.email" (ngModelChange)="onModelChange()" placeholder="exemple@mail.com" />
+                <input matInput type="email" [ngModel]="model.email" disabled placeholder="exemple@mail.com" />
+                <mat-hint>L'adresse email est liée à votre compte Google et ne peut pas être modifiée.</mat-hint>
               </mat-form-field>
+              <div class="account-save-row">
+                <button mat-raised-button color="primary" (click)="saveSettings()" [disabled]="!hasChanges || saving">
+                  @if (saving) {
+                    <mat-spinner diameter="18" style="display:inline-block; margin-right:8px"></mat-spinner>
+                  } @else {
+                    <mat-icon>save</mat-icon>
+                  }
+                  Enregistrer
+                </button>
+              </div>
             </mat-card-content>
           </mat-card>
         </div>
@@ -330,20 +341,16 @@
         </div>
       }
 
-      <!-- Zone de danger -->
+      <!-- Suppression du compte -->
       @if (activeCategory === 'danger') {
         <div class="category-panel">
           <mat-card appearance="outlined" class="danger-card">
             <mat-card-header>
-              <mat-icon mat-card-avatar class="card-icon-danger">warning</mat-icon>
-              <mat-card-title>Zone de danger</mat-card-title>
-              <mat-card-subtitle>Actions irréversibles sur votre compte</mat-card-subtitle>
+              <mat-icon mat-card-avatar class="card-icon-danger">delete_forever</mat-icon>
+              <mat-card-title>Suppression du compte</mat-card-title>
+              <mat-card-subtitle>Cette action est irréversible</mat-card-subtitle>
             </mat-card-header>
             <mat-card-content>
-              <div class="danger-warning">
-                <mat-icon>error_outline</mat-icon>
-                <span>Les actions ci-dessous sont permanentes et ne peuvent pas être annulées.</span>
-              </div>
               <div class="danger-action">
                 <div class="danger-action-text">
                   <p class="toggle-title">Supprimer mon compte</p>
@@ -359,27 +366,6 @@
         </div>
       }
 
-      <!-- Footer -->
-      <div class="settings-footer">
-        @if (hasChanges) {
-          <span class="unsaved-label">
-            <mat-icon>edit_note</mat-icon> Modifications non enregistrées
-          </span>
-        }
-        <div class="button-group">
-          <button mat-stroked-button (click)="resetSettings()" matTooltip="Remettre les valeurs par défaut">
-            <mat-icon>restart_alt</mat-icon> Réinitialiser
-          </button>
-          <button mat-raised-button color="primary" (click)="saveSettings()" [disabled]="!hasChanges || saving">
-            @if (saving) {
-              <mat-spinner diameter="18" style="display:inline-block; margin-right:8px"></mat-spinner>
-            } @else {
-              <mat-icon>save</mat-icon>
-            }
-            Enregistrer
-          </button>
-        </div>
-      </div>
 
     </main>
   </div>

--- a/frontend/src/app/pages/settings/settings.scss
+++ b/frontend/src/app/pages/settings/settings.scss
@@ -206,10 +206,13 @@
   color: var(--mat-sys-primary) !important;
   background: var(--mat-sys-primary-container) !important;
   border-radius: 8px !important;
-  padding: 6px !important;
+  padding: 0 !important;
   font-size: 22px !important;
   width: 36px !important;
   height: 36px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
 }
 
 // ─── Danger card ──────────────────────────────────────────────────────────────
@@ -254,10 +257,13 @@
   color: var(--mat-sys-error) !important;
   background: color-mix(in srgb, var(--mat-sys-error) 15%, transparent) !important;
   border-radius: 8px !important;
-  padding: 6px !important;
+  padding: 0 !important;
   font-size: 22px !important;
   width: 36px !important;
   height: 36px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
 }
 
 // ─── Form fields ──────────────────────────────────────────────────────────────
@@ -445,25 +451,6 @@
 
 // ─── Danger zone ──────────────────────────────────────────────────────────────
 
-.danger-warning {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 16px;
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--mat-sys-error) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--mat-sys-error) 30%, transparent);
-  color: var(--mat-sys-error);
-  font-size: 0.875rem;
-  font-weight: 500;
-
-  mat-icon {
-    font-size: 20px;
-    width: 20px;
-    height: 20px;
-    flex-shrink: 0;
-  }
-}
 
 .danger-action {
   display: flex;
@@ -600,38 +587,10 @@
   }
 }
 
-// ─── Footer ───────────────────────────────────────────────────────────────────
-
-.settings-footer {
+.account-save-row {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 16px;
-  padding: 12px 20px;
-  background: var(--mat-sys-surface-container-low);
-  border: 1px solid var(--mat-sys-outline-variant);
-  border-radius: 14px;
-
-  .unsaved-label {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--mat-sys-tertiary);
-
-    mat-icon {
-      font-size: 18px;
-      width: 18px;
-      height: 18px;
-    }
-  }
-
-  .button-group {
-    display: flex;
-    gap: 10px;
-    margin-left: auto;
-  }
+  justify-content: flex-end;
+  margin-top: 8px;
 }
 
 // ─── Responsive ───────────────────────────────────────────────────────────────
@@ -655,16 +614,6 @@
     button[mat-list-item] {
       flex: 1 1 100px;
       min-width: 90px;
-    }
-  }
-
-  .settings-footer {
-    flex-direction: column;
-    align-items: stretch;
-
-    .button-group {
-      width: 100%;
-      justify-content: flex-end;
     }
   }
 

--- a/frontend/src/app/pages/settings/settings.ts
+++ b/frontend/src/app/pages/settings/settings.ts
@@ -14,6 +14,7 @@ import { MatChipsModule } from '@angular/material/chips';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { AuthService } from '../../../services/auth.service';
 import { DataService } from '../../../services/data-service';
+import { NotificationService } from '../../../services/notification.service';
 
 type CategoryId = 'compte' | 'apparence' | 'notifications' | 'securite' | 'confidentialite' | 'danger';
 
@@ -59,6 +60,7 @@ export class Settings implements OnInit {
   private snackBar = inject(MatSnackBar);
   private auth     = inject(AuthService);
   private dataService = inject(DataService);
+  private notifService = inject(NotificationService);
 
   languages = ['Français', 'English', 'Español'];
 
@@ -68,7 +70,7 @@ export class Settings implements OnInit {
     { id: 'notifications',   label: 'Notifications',   icon: 'notifications' },
     { id: 'securite',        label: 'Sécurité',        icon: 'security'     },
     { id: 'confidentialite', label: 'Confidentialité', icon: 'privacy_tip'  },
-    { id: 'danger',          label: 'Zone de danger',  icon: 'warning'      },
+    { id: 'danger',          label: 'Supprimer le compte', icon: 'delete_forever' },
   ];
 
   activeCategory: CategoryId = 'compte';
@@ -109,12 +111,18 @@ export class Settings implements OnInit {
 
   setTheme(theme: 'light' | 'dark') {
     this.model.theme = theme;
-    this.onModelChange();
+    this.applyTheme(theme);
+    this.saveLocalPrefs();
   }
 
   private applyTheme(theme: 'light' | 'dark') {
     document.body.classList.toggle('dark-theme', theme === 'dark');
-    document.documentElement.classList.toggle('dark-theme', theme === 'dark');
+  }
+
+  saveLocalPrefs() {
+    const { username, email, ...prefs } = this.model;
+    localStorage.setItem('app-settings', JSON.stringify(prefs));
+    this.notifService.setEnabled(this.model.notifications);
   }
 
   saveSettings() {

--- a/frontend/src/services/notification.service.ts
+++ b/frontend/src/services/notification.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, signal, computed } from '@angular/core';
+
+export interface AppNotification {
+  id: number;
+  message: string;
+  type: 'success' | 'error' | 'info';
+  timestamp: Date;
+  read: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  private _notifications = signal<AppNotification[]>([]);
+  private _enabled = signal<boolean>(true);
+  private _nextId = 0;
+
+  notifications = this._notifications.asReadonly();
+  unreadCount = computed(() => this._notifications().filter(n => !n.read).length);
+
+  constructor() {
+    const raw = localStorage.getItem('app-settings');
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        this._enabled.set(parsed.notifications ?? true);
+      } catch { /* ignore */ }
+    }
+  }
+
+  setEnabled(enabled: boolean) {
+    this._enabled.set(enabled);
+  }
+
+  push(message: string, type: 'success' | 'error' | 'info' = 'info') {
+    if (!this._enabled()) return;
+    this._notifications.update(list =>
+      [{ id: this._nextId++, message, type, timestamp: new Date(), read: false }, ...list].slice(0, 20)
+    );
+  }
+
+  markAllRead() {
+    this._notifications.update(list => list.map(n => ({ ...n, read: true })));
+  }
+
+  clear() {
+    this._notifications.set([]);
+  }
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -20,20 +20,15 @@ html {
 }
 
 body {
-  // Default the application to a light color theme. This can be changed to
-  // `dark` to enable the dark color theme, or to `light dark` to defer to the
-  // user's system settings.
   color-scheme: light;
-
-  // Set a default background, font and text colors for the application using
-  // Angular Material's system-level CSS variables. Learn more about these
-  // variables at https://material.angular.dev/guide/system-variables
   background-color: var(--mat-sys-surface);
   color: var(--mat-sys-on-surface);
   font: var(--mat-sys-body-medium);
-
-  // Reset the user agent margin.
   margin: 0;
   height: 100%;
+}
+
+body.dark-theme {
+  color-scheme: dark;
 }
 /* You can add global styles to this file, and also import other style files */


### PR DESCRIPTION
- Dark mode: active via color-scheme, persisted in localStorage, restored on startup
- Notifications: NotificationService + cloche navbar avec badge et dropdown
- Settings: thème et prefs auto-sauvegardés au clic (sans bouton Enregistrer)
- Settings: onglet "Zone de danger" renommé "Supprimer le compte", épuré
- Settings: icônes centrées dans leurs cadres (flexbox)
- Email: champ en lecture seule avec message explicatif