### PR TITLE
feat: package Python backtest-export (#50)

### DIFF
--- a/backtest-export/README.md
+++ b/backtest-export/README.md
@@ -1,0 +1,269 @@
+# backtest-export
+
+Package Python pour exporter vos résultats de backtest au format JSON compatible avec la plateforme.
+
+Ce package **n'est pas un moteur de backtest**. Vous faites votre backtest avec vos propres outils (Python, notebooks, etc.), puis vous utilisez `backtest-export` pour formater et exporter vos résultats.
+
+---
+
+## Prérequis
+
+- **Python 3.10** ou plus récent
+- **pip** (inclus avec Python)
+
+Vérifiez votre version :
+
+```bash
+python --version   # doit afficher Python 3.10+
+```
+
+---
+
+## Installation
+
+Depuis la racine du projet, lancez :
+
+```bash
+pip install -e backtest-export/
+```
+
+> Le flag `-e` installe le package en mode "editable" (développement). Toute modification au code source est immédiatement disponible.
+
+---
+
+## Guide étape par étape
+
+### Étape 1 — Créer un backtest
+
+Créez un fichier Python (par exemple `mon_export.py`) et initialisez un backtest :
+
+```python
+from backtest_export import Backtest
+
+bt = Backtest(
+    ticker="AAPL",       # Le symbole boursier que vous avez backtesté
+    period="1Y",         # La période du backtest (ex: "6M", "1Y", "5Y")
+    capital=10000,       # Le capital initial en dollars
+    strategy="Ma Stratégie RSI"  # Le nom de votre stratégie (optionnel)
+)
+```
+
+| Paramètre  | Obligatoire | Description |
+|------------|------------|-------------|
+| `ticker`   | Oui        | Symbole boursier (ex: "AAPL", "TSLA", "BTC-USD") |
+| `period`   | Oui        | Période du backtest (ex: "6M", "1Y", "5Y") |
+| `capital`  | Oui        | Capital initial en dollars |
+| `strategy` | Non        | Nom de la stratégie (défaut: "Custom Strategy") |
+
+### Étape 2 — Ajouter vos trades
+
+Pour chaque trade de votre backtest, appelez `add_trade()` :
+
+```python
+# Trade long : achat à 150$, vente à 158$
+bt.add_trade(
+    entry_time="2025-06-15",          # Date d'entrée (format YYYY-MM-DD)
+    exit_time="2025-06-20",           # Date de sortie
+    direction="long",                  # "long" (achat) ou "short" (vente à découvert)
+    entry_price=150.25,               # Prix d'entrée
+    exit_price=158.40,                # Prix de sortie
+    fees=2.50,                        # Frais de transaction (optionnel, défaut: 0)
+)
+
+# Trade short : vente à découvert à 200$, rachat à 185$
+bt.add_trade(
+    entry_time="2025-07-01T09:30:00",  # Vous pouvez aussi utiliser l'heure
+    exit_time="2025-07-10T16:00:00",
+    direction="short",
+    entry_price=200.0,
+    exit_price=185.0,
+)
+```
+
+| Paramètre     | Obligatoire | Description |
+|---------------|------------|-------------|
+| `entry_time`  | Oui        | Date/heure d'entrée. Formats acceptés : `"2025-06-15"`, `"2025-06-15 09:30:00"`, `"2025-06-15T09:30:00"` |
+| `exit_time`   | Oui        | Date/heure de sortie (doit être après `entry_time`) |
+| `direction`   | Oui        | `"long"` ou `"short"` |
+| `entry_price` | Oui        | Prix d'entrée (nombre) |
+| `exit_price`  | Oui        | Prix de sortie (nombre) |
+| `fees`        | Non        | Frais de transaction (défaut: 0) |
+| `pnl_pct`     | Non        | P&L en % — calculé automatiquement si omis |
+
+> Le P&L (profit/perte en pourcentage) est calculé automatiquement à partir des prix et des frais. Vous pouvez le fournir vous-même si vous avez un calcul personnalisé.
+
+### Étape 3 — Ajouter des indicateurs (optionnel)
+
+Si vous voulez visualiser des indicateurs sur les graphiques de la plateforme :
+
+```python
+bt.add_series(
+    id="rsi_14",                     # Identifiant unique
+    label="RSI (14)",                # Nom affiché sur le graphique
+    type="line",                     # Type : "line", "histogram", ou "area"
+    color="#2196F3",                 # Couleur en hexadécimal (optionnel)
+    data=[                           # Vos données (liste de {time, value})
+        {"time": "2025-06-01", "value": 45.2},
+        {"time": "2025-06-02", "value": 52.1},
+        {"time": "2025-06-03", "value": 68.7},
+    ],
+    reference_lines=[                # Lignes de référence (optionnel)
+        {"value": 70, "label": "Surachat", "style": "dashed"},
+        {"value": 30, "label": "Survente", "style": "dashed"},
+    ],
+)
+```
+
+| Paramètre         | Obligatoire | Description |
+|-------------------|------------|-------------|
+| `id`              | Oui        | Identifiant unique de la série |
+| `label`           | Oui        | Nom affiché |
+| `type`            | Non        | `"line"` (défaut), `"histogram"`, ou `"area"` |
+| `data`            | Oui        | Liste de `{"time": "...", "value": ...}` |
+| `color`           | Non        | Couleur hex (ex: `"#FF5722"`) |
+| `reference_lines` | Non        | Lignes horizontales de référence |
+
+### Étape 4 — Exporter le JSON
+
+```python
+bt.export("mon_backtest.json")
+```
+
+C'est tout ! Le fichier `mon_backtest.json` est créé avec toutes vos données formatées.
+
+> Si vos données contiennent des erreurs (direction invalide, dates incohérentes, etc.), le package lèvera une erreur explicite **avant** d'écrire le fichier.
+
+### Étape 5 — Uploader sur la plateforme
+
+1. Ouvrez la plateforme dans votre navigateur
+2. Allez sur la page **Mode Avancé**
+3. Cliquez sur **Upload JSON**
+4. Sélectionnez votre fichier `mon_backtest.json`
+5. La plateforme calculera automatiquement toutes les métriques (Sharpe, drawdown, win rate, etc.) et affichera les résultats
+
+---
+
+## Exemple complet
+
+```python
+from backtest_export import Backtest
+
+# Créer le backtest
+bt = Backtest(ticker="TSLA", period="6M", capital=50000, strategy="RSI Mean Reversion")
+
+# Ajouter les trades
+bt.add_trade(
+    entry_time="2025-01-15T09:30:00",
+    exit_time="2025-01-22T16:00:00",
+    direction="long",
+    entry_price=245.50,
+    exit_price=262.30,
+    fees=10.0,
+)
+bt.add_trade(
+    entry_time="2025-02-03",
+    exit_time="2025-02-14",
+    direction="short",
+    entry_price=270.00,
+    exit_price=251.00,
+)
+bt.add_trade(
+    entry_time="2025-03-01",
+    exit_time="2025-03-12",
+    direction="long",
+    entry_price=248.00,
+    exit_price=259.50,
+)
+
+# Ajouter l'indicateur RSI
+bt.add_series(
+    id="rsi_14",
+    label="RSI (14)",
+    type="line",
+    color="#2196F3",
+    data=[
+        {"time": "2025-01-15", "value": 28.5},
+        {"time": "2025-02-03", "value": 74.2},
+        {"time": "2025-03-01", "value": 31.0},
+    ],
+    reference_lines=[
+        {"value": 70, "label": "Surachat", "style": "dashed"},
+        {"value": 30, "label": "Survente", "style": "dashed"},
+    ],
+)
+
+# Exporter
+bt.export("tsla_rsi_backtest.json")
+print("Export terminé !")
+```
+
+---
+
+## Utilisation programmatique
+
+Si vous voulez envoyer le JSON directement à l'API sans passer par un fichier :
+
+```python
+import requests
+
+bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+bt.add_trade(...)
+
+# Récupérer le dict Python directement
+payload = bt.to_dict()
+
+# Envoyer à l'API
+response = requests.post("https://votre-plateforme.com/api/backtest/upload", json=payload)
+```
+
+---
+
+## Validation
+
+Le package valide vos données à deux moments :
+
+1. **Immédiatement** quand vous appelez `add_trade()` ou `add_series()` — une erreur est levée tout de suite si les données sont invalides
+2. **À l'export** — une vérification finale de la structure complète
+
+Vous pouvez aussi vérifier manuellement :
+
+```python
+errors = bt.validate()
+if errors:
+    print("Problèmes détectés :")
+    for e in errors:
+        print(f"  - {e}")
+```
+
+---
+
+## Dépannage
+
+| Erreur | Cause | Solution |
+|--------|-------|----------|
+| `direction must be 'long' or 'short'` | Direction invalide | Utilisez `"long"` ou `"short"` uniquement |
+| `exit_time must be after entry_time` | Date de sortie avant l'entrée | Vérifiez l'ordre de vos dates |
+| `entry_price must be a number` | Prix non numérique | Passez un `float` ou `int`, pas une string |
+| `type must be 'line', 'histogram', or 'area'` | Type de série invalide | Utilisez l'un des trois types supportés |
+
+---
+
+## Référence API
+
+### `Backtest(ticker, period, capital, strategy="Custom Strategy")`
+Crée un nouveau backtest.
+
+### `.add_trade(entry_time, exit_time, direction, entry_price, exit_price, fees=0, pnl_pct=None)`
+Ajoute un trade. Retourne `self` (chaînable).
+
+### `.add_series(id, label, type="line", data=None, color=None, reference_lines=None)`
+Ajoute une série d'indicateur custom. Retourne `self` (chaînable).
+
+### `.to_dict()`
+Retourne le payload JSON sous forme de dictionnaire Python.
+
+### `.export(path)`
+Exporte le JSON dans un fichier. Retourne le `Path` absolu du fichier créé.
+
+### `.validate()`
+Vérifie la validité des données. Retourne une liste d'erreurs (vide si tout est ok).

--- a/backtest-export/pyproject.toml
+++ b/backtest-export/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "backtest-export"
+version = "0.1.0"
+description = "Export backtest results to JSON for the backtesting platform"
+requires-python = ">=3.10"
+license = "MIT"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/backtest-export/src/backtest_export/__init__.py
+++ b/backtest-export/src/backtest_export/__init__.py
@@ -1,0 +1,4 @@
+from ._backtest import Backtest
+from ._validation import ValidationError
+
+__all__ = ["Backtest", "ValidationError"]

--- a/backtest-export/src/backtest_export/_backtest.py
+++ b/backtest-export/src/backtest_export/_backtest.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ._time import format_time, parse_time
+from ._validation import (
+    ValidationError,
+    validate_payload,
+    validate_series,
+    validate_trade,
+)
+
+
+def _compute_pnl_pct(
+    direction: str,
+    entry_price: float,
+    exit_price: float,
+    fees: float,
+) -> float:
+    if direction == "long":
+        raw = (exit_price - entry_price) / entry_price * 100
+    else:
+        raw = (entry_price - exit_price) / entry_price * 100
+
+    fee_pct = fees / entry_price * 100 if entry_price != 0 else 0
+    return raw - fee_pct
+
+
+def _build_equity_curve(
+    trades: list[dict], capital_initial: float
+) -> list[dict]:
+    if not trades:
+        return []
+
+    curve: list[dict] = []
+    equity = capital_initial
+
+    first_entry = parse_time(trades[0]["entry_time"])
+    if first_entry:
+        curve.append(
+            {
+                "time": first_entry.strftime("%Y-%m-%d"),
+                "strategy": capital_initial,
+                "market": capital_initial,
+            }
+        )
+
+    for t in trades:
+        pnl = t.get("pnl_pct", 0)
+        equity *= 1 + pnl / 100
+        exit_time = parse_time(t["exit_time"])
+        if exit_time:
+            curve.append(
+                {
+                    "time": exit_time.strftime("%Y-%m-%d"),
+                    "strategy": round(equity, 2),
+                    "market": capital_initial,
+                }
+            )
+
+    return curve
+
+
+class Backtest:
+    def __init__(
+        self,
+        ticker: str,
+        period: str,
+        capital: float,
+        strategy: str = "Custom Strategy",
+    ):
+        self._ticker = ticker
+        self._period = period
+        self._capital = capital
+        self._strategy = strategy
+        self._trades: list[dict[str, Any]] = []
+        self._custom_series: list[dict[str, Any]] = []
+
+    def add_trade(
+        self,
+        entry_time: str | datetime,
+        exit_time: str | datetime,
+        direction: str,
+        entry_price: float,
+        exit_price: float,
+        fees: float = 0,
+        pnl_pct: float | None = None,
+    ) -> Backtest:
+        entry_dt = parse_time(entry_time)
+        exit_dt = parse_time(exit_time)
+
+        entry_str = format_time(entry_dt) if entry_dt else str(entry_time)
+        exit_str = format_time(exit_dt) if exit_dt else str(exit_time)
+
+        trade: dict[str, Any] = {
+            "entry_time": entry_str,
+            "exit_time": exit_str,
+            "direction": direction,
+            "entry_price": entry_price,
+            "exit_price": exit_price,
+        }
+        if fees:
+            trade["fees"] = fees
+
+        errors = validate_trade(trade, len(self._trades))
+        if errors:
+            raise ValidationError(errors)
+
+        if pnl_pct is not None:
+            trade["pnl_pct"] = pnl_pct
+        else:
+            trade["pnl_pct"] = round(
+                _compute_pnl_pct(direction, entry_price, exit_price, fees), 2
+            )
+
+        self._trades.append(trade)
+        return self
+
+    def add_series(
+        self,
+        id: str,
+        label: str,
+        type: str = "line",
+        data: list[dict] | None = None,
+        color: str | None = None,
+        reference_lines: list[dict | float] | None = None,
+    ) -> Backtest:
+        series: dict[str, Any] = {
+            "id": id,
+            "label": label,
+            "type": type,
+            "data": data or [],
+        }
+        if color is not None:
+            series["color"] = color
+        if reference_lines is not None:
+            series["reference_lines"] = reference_lines
+
+        errors = validate_series(series, len(self._custom_series))
+        if errors:
+            raise ValidationError(errors)
+
+        self._custom_series.append(series)
+        return self
+
+    def to_dict(self) -> dict:
+        payload: dict[str, Any] = {
+            "metadata": {
+                "ticker": self._ticker,
+                "period": self._period,
+                "capital_initial": self._capital,
+                "strategy": self._strategy,
+            },
+            "trades": self._trades,
+            "equity_curve": _build_equity_curve(self._trades, self._capital),
+        }
+        if self._custom_series:
+            payload["custom_series"] = self._custom_series
+        return payload
+
+    def validate(self) -> list[str]:
+        return validate_payload(self.to_dict())
+
+    def export(self, path: str | Path) -> Path:
+        payload = self.to_dict()
+        errors = validate_payload(payload)
+        if errors:
+            raise ValidationError(errors)
+
+        out = Path(path)
+        out.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        return out.resolve()

--- a/backtest-export/src/backtest_export/_time.py
+++ b/backtest-export/src/backtest_export/_time.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+_FORMATS = ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d")
+
+
+def parse_time(value: str | datetime) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str):
+        return None
+    for fmt in _FORMATS:
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def format_time(dt: datetime) -> str:
+    if dt.hour or dt.minute or dt.second:
+        return dt.strftime("%Y-%m-%dT%H:%M:%S")
+    return dt.strftime("%Y-%m-%d")

--- a/backtest-export/src/backtest_export/_validation.py
+++ b/backtest-export/src/backtest_export/_validation.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from ._time import parse_time
+
+VALID_DIRECTIONS = {"long", "short"}
+VALID_SERIES_TYPES = {"line", "histogram", "area"}
+
+
+class ValidationError(Exception):
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("\n".join(errors))
+
+
+def validate_trade(trade: dict, index: int) -> list[str]:
+    errors: list[str] = []
+    prefix = f"trades[{index}]"
+
+    for field in ("entry_time", "exit_time", "direction", "entry_price", "exit_price"):
+        if field not in trade:
+            errors.append(f"{prefix}.{field} is required.")
+
+    if "direction" in trade and trade["direction"] not in VALID_DIRECTIONS:
+        errors.append(
+            f"{prefix}.direction must be 'long' or 'short', got '{trade['direction']}'."
+        )
+
+    for price_field in ("entry_price", "exit_price"):
+        if price_field in trade and not isinstance(trade[price_field], (int, float)):
+            errors.append(f"{prefix}.{price_field} must be a number.")
+
+    entry = parse_time(trade.get("entry_time"))
+    exit_ = parse_time(trade.get("exit_time"))
+    if entry and exit_ and exit_ <= entry:
+        errors.append(f"{prefix}.exit_time must be after entry_time.")
+
+    return errors
+
+
+def validate_series(series: dict, index: int) -> list[str]:
+    errors: list[str] = []
+    prefix = f"custom_series[{index}]"
+
+    for field in ("id", "label", "data"):
+        if field not in series:
+            errors.append(f"{prefix}.{field} is required.")
+
+    if "type" in series and series["type"] not in VALID_SERIES_TYPES:
+        errors.append(
+            f"{prefix}.type must be 'line', 'histogram', or 'area', got '{series['type']}'."
+        )
+
+    return errors
+
+
+def validate_payload(payload: dict) -> list[str]:
+    errors: list[str] = []
+
+    meta = payload.get("metadata")
+    if meta is None:
+        errors.append("metadata is required.")
+    elif not isinstance(meta, dict):
+        errors.append("metadata must be an object.")
+    else:
+        for field in ("ticker", "period", "capital_initial", "strategy"):
+            if field not in meta:
+                errors.append(f"metadata.{field} is required.")
+        if "capital_initial" in meta and not isinstance(
+            meta["capital_initial"], (int, float)
+        ):
+            errors.append("metadata.capital_initial must be a number.")
+
+    trades = payload.get("trades")
+    if trades is None:
+        errors.append("trades is required.")
+    elif not isinstance(trades, list):
+        errors.append("trades must be a list.")
+    else:
+        for i, trade in enumerate(trades):
+            errors.extend(validate_trade(trade, i))
+
+    curve = payload.get("equity_curve")
+    if curve is not None and not isinstance(curve, list):
+        errors.append("equity_curve must be a list.")
+
+    series_list = payload.get("custom_series")
+    if series_list is not None:
+        if not isinstance(series_list, list):
+            errors.append("custom_series must be a list.")
+        else:
+            for i, s in enumerate(series_list):
+                errors.extend(validate_series(s, i))
+
+    return errors

--- a/backtest-export/tests/test_backtest.py
+++ b/backtest-export/tests/test_backtest.py
@@ -1,0 +1,160 @@
+import pytest
+from datetime import datetime
+
+from backtest_export import Backtest, ValidationError
+
+
+class TestConstructor:
+    def test_stores_metadata(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        d = bt.to_dict()
+        assert d["metadata"]["ticker"] == "AAPL"
+        assert d["metadata"]["period"] == "1Y"
+        assert d["metadata"]["capital_initial"] == 10000
+        assert d["metadata"]["strategy"] == "Custom Strategy"
+
+    def test_custom_strategy(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000, strategy="MACD")
+        assert bt.to_dict()["metadata"]["strategy"] == "MACD"
+
+
+class TestAddTrade:
+    def test_basic_long(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        bt.add_trade(
+            entry_time="2024-01-15",
+            exit_time="2024-01-20",
+            direction="long",
+            entry_price=100.0,
+            exit_price=110.0,
+        )
+        trades = bt.to_dict()["trades"]
+        assert len(trades) == 1
+        assert trades[0]["pnl_pct"] == 10.0
+
+    def test_short_pnl(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        bt.add_trade(
+            entry_time="2024-01-15",
+            exit_time="2024-01-20",
+            direction="short",
+            entry_price=100.0,
+            exit_price=90.0,
+        )
+        assert bt.to_dict()["trades"][0]["pnl_pct"] == 10.0
+
+    def test_fees_reduce_pnl(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        bt.add_trade(
+            entry_time="2024-01-15",
+            exit_time="2024-01-20",
+            direction="long",
+            entry_price=100.0,
+            exit_price=110.0,
+            fees=5.0,
+        )
+        assert bt.to_dict()["trades"][0]["pnl_pct"] == 5.0
+
+    def test_user_provided_pnl(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        bt.add_trade(
+            entry_time="2024-01-15",
+            exit_time="2024-01-20",
+            direction="long",
+            entry_price=100.0,
+            exit_price=110.0,
+            pnl_pct=42.0,
+        )
+        assert bt.to_dict()["trades"][0]["pnl_pct"] == 42.0
+
+    def test_chaining(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        result = bt.add_trade(
+            entry_time="2024-01-15",
+            exit_time="2024-01-20",
+            direction="long",
+            entry_price=100.0,
+            exit_price=110.0,
+        )
+        assert result is bt
+
+    def test_invalid_direction_raises(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        with pytest.raises(ValidationError, match="'long' or 'short'"):
+            bt.add_trade(
+                entry_time="2024-01-15",
+                exit_time="2024-01-20",
+                direction="up",
+                entry_price=100.0,
+                exit_price=110.0,
+            )
+
+    def test_exit_before_entry_raises(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        with pytest.raises(ValidationError, match="after entry_time"):
+            bt.add_trade(
+                entry_time="2024-01-20",
+                exit_time="2024-01-15",
+                direction="long",
+                entry_price=100.0,
+                exit_price=110.0,
+            )
+
+    def test_accepts_datetime_objects(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        bt.add_trade(
+            entry_time=datetime(2024, 1, 15, 9, 30),
+            exit_time=datetime(2024, 1, 20, 16, 0),
+            direction="long",
+            entry_price=100.0,
+            exit_price=110.0,
+        )
+        trade = bt.to_dict()["trades"][0]
+        assert trade["entry_time"] == "2024-01-15T09:30:00"
+        assert trade["exit_time"] == "2024-01-20T16:00:00"
+
+
+class TestAddSeries:
+    def test_basic_series(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        bt.add_series(
+            id="rsi",
+            label="RSI (14)",
+            type="line",
+            data=[{"time": "2024-01-15", "value": 50}],
+            color="#2196F3",
+        )
+        series = bt.to_dict()["custom_series"]
+        assert len(series) == 1
+        assert series[0]["id"] == "rsi"
+        assert series[0]["color"] == "#2196F3"
+
+    def test_invalid_type_raises(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        with pytest.raises(ValidationError, match="'line', 'histogram', or 'area'"):
+            bt.add_series(id="x", label="X", type="bar", data=[])
+
+    def test_chaining(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        result = bt.add_series(id="x", label="X", data=[])
+        assert result is bt
+
+
+class TestEquityCurve:
+    def test_equity_curve_built(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        bt.add_trade(
+            entry_time="2024-01-15",
+            exit_time="2024-01-20",
+            direction="long",
+            entry_price=100.0,
+            exit_price=110.0,
+        )
+        curve = bt.to_dict()["equity_curve"]
+        assert len(curve) == 2
+        assert curve[0]["strategy"] == 10000
+        assert curve[1]["strategy"] == 11000.0
+
+    def test_empty_trades_no_curve(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        assert bt.to_dict()["equity_curve"] == []

--- a/backtest-export/tests/test_export.py
+++ b/backtest-export/tests/test_export.py
@@ -1,0 +1,111 @@
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from backtest_export import Backtest, ValidationError
+
+
+class TestExport:
+    def test_export_creates_valid_json(self, tmp_path):
+        out = tmp_path / "result.json"
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000, strategy="MACD")
+        bt.add_trade(
+            entry_time="2024-01-15",
+            exit_time="2024-01-20",
+            direction="long",
+            entry_price=150.0,
+            exit_price=158.0,
+        )
+        bt.add_series(
+            id="rsi_14",
+            label="RSI (14)",
+            type="line",
+            color="#2196F3",
+            data=[{"time": "2024-01-15", "value": 45.2}],
+            reference_lines=[
+                {"value": 70, "label": "Overbought", "style": "dashed"},
+                {"value": 30, "label": "Oversold", "style": "dashed"},
+            ],
+        )
+
+        result_path = bt.export(out)
+        assert result_path.exists()
+
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data["metadata"]["ticker"] == "AAPL"
+        assert len(data["trades"]) == 1
+        assert len(data["equity_curve"]) == 2
+        assert len(data["custom_series"]) == 1
+
+    def test_export_returns_absolute_path(self, tmp_path):
+        out = tmp_path / "result.json"
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        bt.add_trade(
+            entry_time="2024-01-15",
+            exit_time="2024-01-20",
+            direction="long",
+            entry_price=100.0,
+            exit_price=110.0,
+        )
+        result = bt.export(out)
+        assert result.is_absolute()
+
+    def test_to_dict_matches_export(self, tmp_path):
+        out = tmp_path / "result.json"
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        bt.add_trade(
+            entry_time="2024-01-15",
+            exit_time="2024-01-20",
+            direction="long",
+            entry_price=100.0,
+            exit_price=110.0,
+        )
+        dict_result = bt.to_dict()
+        bt.export(out)
+        file_result = json.loads(out.read_text(encoding="utf-8"))
+        assert dict_result == file_result
+
+    def test_validate_returns_errors(self):
+        bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+        errors = bt.validate()
+        assert errors == []
+
+    def test_cross_validation_with_backend_format(self, tmp_path):
+        """The exported JSON should have the exact structure the backend expects."""
+        out = tmp_path / "result.json"
+        bt = Backtest(ticker="TSLA", period="6M", capital=50000, strategy="RSI Mean Reversion")
+        bt.add_trade(
+            entry_time="2024-03-01T09:30:00",
+            exit_time="2024-03-05T16:00:00",
+            direction="long",
+            entry_price=200.0,
+            exit_price=215.0,
+            fees=5.0,
+        )
+        bt.add_trade(
+            entry_time="2024-04-01",
+            exit_time="2024-04-10",
+            direction="short",
+            entry_price=210.0,
+            exit_price=195.0,
+        )
+        bt.export(out)
+
+        data = json.loads(out.read_text(encoding="utf-8"))
+
+        assert "metadata" in data
+        assert "trades" in data
+        assert "equity_curve" in data
+
+        meta = data["metadata"]
+        assert all(k in meta for k in ("ticker", "period", "capital_initial", "strategy"))
+        assert isinstance(meta["capital_initial"], (int, float))
+
+        for trade in data["trades"]:
+            assert all(
+                k in trade
+                for k in ("entry_time", "exit_time", "direction", "entry_price", "exit_price")
+            )
+            assert trade["direction"] in ("long", "short")

--- a/backtest-export/tests/test_validation.py
+++ b/backtest-export/tests/test_validation.py
@@ -1,0 +1,133 @@
+import pytest
+
+from backtest_export._validation import (
+    ValidationError,
+    validate_payload,
+    validate_series,
+    validate_trade,
+)
+
+
+class TestValidateTrade:
+    def test_valid_trade(self):
+        trade = {
+            "entry_time": "2024-01-15",
+            "exit_time": "2024-01-20",
+            "direction": "long",
+            "entry_price": 150.0,
+            "exit_price": 155.0,
+        }
+        assert validate_trade(trade, 0) == []
+
+    def test_missing_required_field(self):
+        trade = {"entry_time": "2024-01-15", "direction": "long"}
+        errors = validate_trade(trade, 0)
+        assert any("exit_time" in e for e in errors)
+        assert any("entry_price" in e for e in errors)
+        assert any("exit_price" in e for e in errors)
+
+    def test_invalid_direction(self):
+        trade = {
+            "entry_time": "2024-01-15",
+            "exit_time": "2024-01-20",
+            "direction": "up",
+            "entry_price": 150.0,
+            "exit_price": 155.0,
+        }
+        errors = validate_trade(trade, 0)
+        assert any("'long' or 'short'" in e for e in errors)
+
+    def test_non_numeric_price(self):
+        trade = {
+            "entry_time": "2024-01-15",
+            "exit_time": "2024-01-20",
+            "direction": "long",
+            "entry_price": "not_a_number",
+            "exit_price": 155.0,
+        }
+        errors = validate_trade(trade, 0)
+        assert any("entry_price" in e and "number" in e for e in errors)
+
+    def test_exit_before_entry(self):
+        trade = {
+            "entry_time": "2024-01-20",
+            "exit_time": "2024-01-15",
+            "direction": "long",
+            "entry_price": 150.0,
+            "exit_price": 155.0,
+        }
+        errors = validate_trade(trade, 0)
+        assert any("after entry_time" in e for e in errors)
+
+
+class TestValidateSeries:
+    def test_valid_series(self):
+        series = {
+            "id": "rsi",
+            "label": "RSI",
+            "type": "line",
+            "data": [{"time": "2024-01-15", "value": 50}],
+        }
+        assert validate_series(series, 0) == []
+
+    def test_missing_id(self):
+        series = {"label": "RSI", "data": []}
+        errors = validate_series(series, 0)
+        assert any("id" in e for e in errors)
+
+    def test_invalid_type(self):
+        series = {"id": "x", "label": "X", "type": "bar", "data": []}
+        errors = validate_series(series, 0)
+        assert any("'line', 'histogram', or 'area'" in e for e in errors)
+
+
+class TestValidatePayload:
+    def test_valid_payload(self):
+        payload = {
+            "metadata": {
+                "ticker": "AAPL",
+                "period": "1Y",
+                "capital_initial": 10000,
+                "strategy": "Test",
+            },
+            "trades": [
+                {
+                    "entry_time": "2024-01-15",
+                    "exit_time": "2024-01-20",
+                    "direction": "long",
+                    "entry_price": 150.0,
+                    "exit_price": 155.0,
+                }
+            ],
+        }
+        assert validate_payload(payload) == []
+
+    def test_missing_metadata(self):
+        payload = {"trades": []}
+        errors = validate_payload(payload)
+        assert any("metadata" in e for e in errors)
+
+    def test_missing_trades(self):
+        payload = {
+            "metadata": {
+                "ticker": "AAPL",
+                "period": "1Y",
+                "capital_initial": 10000,
+                "strategy": "Test",
+            }
+        }
+        errors = validate_payload(payload)
+        assert any("trades" in e for e in errors)
+
+    def test_non_numeric_capital(self):
+        payload = {
+            "metadata": {
+                "ticker": "AAPL",
+                "period": "1Y",
+                "capital_initial": "oops",
+                "strategy": "Test",
+            },
+            "trades": [],
+        }
+        errors = validate_payload(payload)
+        assert any("capital_initial" in e and "number" in e for e in errors)

--- a/frontend/src/app/pages/advanced/advanced.html
+++ b/frontend/src/app/pages/advanced/advanced.html
@@ -2,6 +2,99 @@
   <h1>Mode Avancé</h1>
   <p class="subtitle">Importez vos résultats de backtest au format JSON pour les analyser.</p>
 
+  <!-- Guide step-by-step -->
+  <button class="guide-toggle" (click)="toggleGuide()">
+    <mat-icon>{{ showGuide() ? 'expand_less' : 'help_outline' }}</mat-icon>
+    {{ showGuide() ? 'Masquer le guide' : 'Comment ça marche ?' }}
+  </button>
+
+  @if (showGuide()) {
+    <div class="guide-panel">
+      <div class="guide-step">
+        <span class="step-number">1</span>
+        <div class="step-content">
+          <h3>Installer l'outil d'export</h3>
+          <p>Ouvrez un terminal et lancez :</p>
+          <pre class="code-block">pip install -e backtest-export/</pre>
+          <p class="hint">Nécessite Python 3.10+. Vérifiez avec <code>python --version</code>.</p>
+        </div>
+      </div>
+
+      <div class="guide-step">
+        <span class="step-number">2</span>
+        <div class="step-content">
+          <h3>Créer votre fichier JSON</h3>
+          <p>Créez un fichier Python et ajoutez vos trades :</p>
+          <pre class="code-block">from backtest_export import Backtest
+
+bt = Backtest(ticker="AAPL", period="1Y", capital=10000)
+
+bt.add_trade(
+    entry_time="2025-01-15",
+    exit_time="2025-01-22",
+    direction="long",
+    entry_price=150.25,
+    exit_price=158.40,
+    fees=2.50
+)
+
+bt.export("mon_backtest.json")</pre>
+          <p class="hint">Le P&amp;L et la courbe d'équité sont calculés automatiquement.</p>
+        </div>
+      </div>
+
+      <div class="guide-step">
+        <span class="step-number">3</span>
+        <div class="step-content">
+          <h3>Ajouter des indicateurs <span class="optional-badge">optionnel</span></h3>
+          <p>Visualisez vos indicateurs sur les graphiques :</p>
+          <pre class="code-block">bt.add_series(
+    id="rsi_14",
+    label="RSI (14)",
+    type="line",        # "line", "histogram" ou "area"
+    color="#2196F3",
+    data=[
+        {{ '{' }}"time": "2025-01-15", "value": 45.2{{ '}' }},
+        {{ '{' }}"time": "2025-01-16", "value": 52.1{{ '}' }},
+    ]
+)</pre>
+        </div>
+      </div>
+
+      <div class="guide-step">
+        <span class="step-number">4</span>
+        <div class="step-content">
+          <h3>Uploader et analyser</h3>
+          <p>Glissez votre fichier <code>.json</code> ci-dessous ou collez le contenu JSON, puis cliquez <strong>Analyser</strong>.</p>
+          <p>La plateforme calculera automatiquement toutes les métriques : Sharpe, Sortino, drawdown, win rate, etc.</p>
+        </div>
+      </div>
+
+      <div class="guide-format">
+        <h3>Format JSON attendu</h3>
+        <pre class="code-block">{{ '{' }}
+  "metadata": {{ '{' }}
+    "ticker": "AAPL",
+    "period": "1Y",
+    "capital_initial": 10000,
+    "strategy": "Ma Stratégie"
+  {{ '}' }},
+  "trades": [
+    {{ '{' }}
+      "entry_time": "2025-01-15",
+      "exit_time": "2025-01-22",
+      "direction": "long",
+      "entry_price": 150.25,
+      "exit_price": 158.40,
+      "fees": 2.50
+    {{ '}' }}
+  ],
+  "custom_series": []
+{{ '}' }}</pre>
+      </div>
+    </div>
+  }
+
   <!-- Toggle file / paste -->
   <div class="mode-toggle">
     <button mat-stroked-button

--- a/frontend/src/app/pages/advanced/advanced.scss
+++ b/frontend/src/app/pages/advanced/advanced.scss
@@ -15,6 +15,139 @@ h1 { margin: 0 0 4px; font-size: 1.6rem; }
   font-size: 0.95rem;
 }
 
+/* Guide toggle button */
+.guide-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 1px solid #444;
+  border-radius: 8px;
+  color: #4fc3f7;
+  font-size: 0.9rem;
+  padding: 8px 16px;
+  cursor: pointer;
+  margin-bottom: 20px;
+  transition: background 0.2s, border-color 0.2s;
+
+  &:hover {
+    background: #1a2530;
+    border-color: #4fc3f7;
+  }
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+/* Guide panel */
+.guide-panel {
+  background: #141414;
+  border: 1px solid #333;
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.guide-step {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 24px;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
+.step-number {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #4fc3f7;
+  color: #000;
+  font-weight: 700;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.step-content {
+  flex: 1;
+
+  h3 {
+    margin: 4px 0 8px;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #e0e0e0;
+  }
+
+  p {
+    margin: 0 0 8px;
+    font-size: 0.88rem;
+    color: #aaa;
+    line-height: 1.5;
+  }
+}
+
+.optional-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: #888;
+  background: #2a2a2a;
+  padding: 2px 8px;
+  border-radius: 4px;
+  vertical-align: middle;
+  margin-left: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.code-block {
+  background: #0d0d0d;
+  color: #c5e1a5;
+  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  padding: 12px 14px;
+  border-radius: 6px;
+  border: 1px solid #2a2a2a;
+  overflow-x: auto;
+  white-space: pre;
+  margin: 8px 0;
+}
+
+.hint {
+  font-size: 0.8rem !important;
+  color: #666 !important;
+  font-style: italic;
+
+  code {
+    background: #1a1a1a;
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 0.78rem;
+    color: #aaa;
+  }
+}
+
+.guide-format {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid #2a2a2a;
+
+  h3 {
+    margin: 0 0 10px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #e0e0e0;
+  }
+}
+
 /* Toggle file / paste */
 .mode-toggle {
   display: flex;

--- a/frontend/src/app/pages/advanced/advanced.ts
+++ b/frontend/src/app/pages/advanced/advanced.ts
@@ -31,6 +31,11 @@ export class Advanced {
   isLoading    = signal<boolean>(false);
   errorMessage = signal<string | null>(null);
   isDragOver   = signal<boolean>(false);
+  showGuide    = signal<boolean>(false);
+
+  toggleGuide() {
+    this.showGuide.update(v => !v);
+  }
 
   setMode(mode: 'file' | 'paste') {
     this.inputMode.set(mode);


### PR DESCRIPTION
## Summary

- Nouveau package Python standalone `backtest-export/` pour exporter des resultats de backtest en JSON compatible avec `POST /api/backtest/upload`
- API builder pattern : `Backtest()`, `.add_trade()`, `.add_series()`, `.export()`
- Validation fail-fast alignee sur `backend/validator.py`, auto-calcul PnL et equity curve
- 32 tests, zero dependance externe, README step-by-step en francais

## Closes

Closes #50

## Test plan

- [ ] `pip install -e backtest-export/` installe sans erreur
- [ ] `pytest backtest-export/tests/ -v` : 32 tests passent
- [ ] Le JSON exporte passe `backend/validator.py:validate_upload()` sans erreur
- [ ] Le README documente l'installation et l'utilisation avec exemples