### PR TITLE
feat: nouveaux indicateurs EMA Crossover, Bollinger, Stochastic, OBV

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -201,7 +201,15 @@ def delete_backtest(backtest_id: int, db: Session = Depends(get_db)):
 
 @app.get("/api/strategies")
 def list_strategies():
-    return {"strategies": list(STRATEGIES_REGISTRY.keys())}
+    result = {}
+    for key, cls in STRATEGIES_REGISTRY.items():
+        instance = cls()
+        result[key] = {
+            "name": instance.name,
+            "description": instance.description,
+            "category": instance.category,
+        }
+    return {"strategies": result}
 
 
 @app.post("/api/backtest/upload")

--- a/backend/strategies/__init__.py
+++ b/backend/strategies/__init__.py
@@ -12,6 +12,10 @@ C'est tout — la route FastAPI la détectera automatiquement.
 from .macd import MACDStrategy
 from .rsi import RSIStrategy
 from .ma_crossover import MACrossoverStrategy
+from .ema_crossover import EMACrossoverStrategy
+from .bollinger_bands import BollingerBandsStrategy
+from .stochastic import StochasticStrategy
+from .obv import OBVStrategy
 from .base import BaseStrategy
 
 # Clé = nom utilisé dans la requête JSON  {"strategy": "macd", ...}
@@ -19,6 +23,10 @@ STRATEGIES_REGISTRY: dict[str, type[BaseStrategy]] = {
     "macd": MACDStrategy,
     "rsi": RSIStrategy,
     "ma_crossover": MACrossoverStrategy,
+    "ema_crossover": EMACrossoverStrategy,
+    "bollinger_bands": BollingerBandsStrategy,
+    "stochastic": StochasticStrategy,
+    "obv": OBVStrategy,
 }
 
 __all__ = [
@@ -26,5 +34,9 @@ __all__ = [
     "MACDStrategy",
     "RSIStrategy",
     "MACrossoverStrategy",
+    "EMACrossoverStrategy",
+    "BollingerBandsStrategy",
+    "StochasticStrategy",
+    "OBVStrategy",
     "STRATEGIES_REGISTRY",
 ]

--- a/backend/strategies/base.py
+++ b/backend/strategies/base.py
@@ -36,3 +36,15 @@ class BaseStrategy(ABC):
     def name(self) -> str:
         """Nom court de la stratégie (ex: 'macd', 'rsi', 'ma_crossover')."""
         ...
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Description intuitive de la stratégie."""
+        ...
+
+    @property
+    @abstractmethod
+    def category(self) -> str:
+        """Catégorie : 'trend', 'momentum' ou 'volume'."""
+        ...

--- a/backend/strategies/bollinger_bands.py
+++ b/backend/strategies/bollinger_bands.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pandas as pd
+from .base import BaseStrategy
+
+
+class BollingerBandsStrategy(BaseStrategy):
+    """
+    Stratégie Bollinger Bands.
+
+    Signal :
+        +1 si prix < bande basse   → survente, rebond probable
+        -1 si prix > bande haute   → surachat, correction probable
+         0 sinon                    → neutre
+    """
+
+    def __init__(self, period: int = 20, std_dev: float = 2.0):
+        self.period = period
+        self.std_dev = std_dev
+
+    @property
+    def name(self) -> str:
+        return "bollinger_bands"
+
+    @property
+    def description(self) -> str:
+        return "Bandes de Bollinger : long sous la bande basse, short au-dessus de la bande haute"
+
+    @property
+    def category(self) -> str:
+        return "trend"
+
+    def compute_signals(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+
+        df["bb_middle"] = df["Close"].rolling(self.period).mean()
+        bb_std = df["Close"].rolling(self.period).std()
+        df["bb_upper"] = df["bb_middle"] + self.std_dev * bb_std
+        df["bb_lower"] = df["bb_middle"] - self.std_dev * bb_std
+
+        df["signal"] = np.where(
+            df["Close"] < df["bb_lower"], 1,
+            np.where(df["Close"] > df["bb_upper"], -1, 0)
+        )
+
+        return df.dropna()

--- a/backend/strategies/ema_crossover.py
+++ b/backend/strategies/ema_crossover.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pandas as pd
+from .base import BaseStrategy
+
+
+class EMACrossoverStrategy(BaseStrategy):
+    """
+    Stratégie EMA Crossover (Exponential Moving Average).
+
+    Signal :
+        +1 si EMA_fast > EMA_slow  → tendance haussière
+        -1 si EMA_fast < EMA_slow  → tendance baissière
+    """
+
+    def __init__(self, fast: int = 12, slow: int = 26):
+        if fast >= slow:
+            raise ValueError(f"fast ({fast}) doit être inférieur à slow ({slow})")
+        self.fast = fast
+        self.slow = slow
+
+    @property
+    def name(self) -> str:
+        return "ema_crossover"
+
+    @property
+    def description(self) -> str:
+        return "Croisement d'EMA : plus réactif que le MA Crossover car l'EMA pondère les prix récents"
+
+    @property
+    def category(self) -> str:
+        return "trend"
+
+    def compute_signals(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+
+        df["ema_fast"] = df["Close"].ewm(span=self.fast, adjust=False).mean()
+        df["ema_slow"] = df["Close"].ewm(span=self.slow, adjust=False).mean()
+
+        df["signal"] = np.where(df["ema_fast"] > df["ema_slow"], 1, -1)
+
+        return df.dropna()

--- a/backend/strategies/ma_crossover.py
+++ b/backend/strategies/ma_crossover.py
@@ -27,6 +27,14 @@ class MACrossoverStrategy(BaseStrategy):
     def name(self) -> str:
         return "ma_crossover"
 
+    @property
+    def description(self) -> str:
+        return "Croisement de moyennes mobiles simples"
+
+    @property
+    def category(self) -> str:
+        return "trend"
+
     def compute_signals(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.copy()
 

--- a/backend/strategies/macd.py
+++ b/backend/strategies/macd.py
@@ -27,6 +27,14 @@ class MACDStrategy(BaseStrategy):
     def name(self) -> str:
         return "macd"
 
+    @property
+    def description(self) -> str:
+        return "MACD : long quand la ligne MACD croise au-dessus du signal"
+
+    @property
+    def category(self) -> str:
+        return "momentum"
+
     def compute_signals(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.copy()
 

--- a/backend/strategies/obv.py
+++ b/backend/strategies/obv.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas as pd
+from .base import BaseStrategy
+
+
+class OBVStrategy(BaseStrategy):
+    """
+    Stratégie OBV (On-Balance Volume).
+
+    Signal :
+        +1 si OBV > OBV_MA  → volume confirme la hausse
+        -1 si OBV < OBV_MA  → volume confirme la baisse
+    """
+
+    def __init__(self, signal_period: int = 20):
+        self.signal_period = signal_period
+
+    @property
+    def name(self) -> str:
+        return "obv"
+
+    @property
+    def description(self) -> str:
+        return "OBV : confirme la tendance par le volume cumulé"
+
+    @property
+    def category(self) -> str:
+        return "volume"
+
+    def compute_signals(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+
+        direction = np.sign(df["Close"].diff().fillna(0))
+        df["obv"] = (direction * df["Volume"]).cumsum()
+        df["obv_ma"] = df["obv"].rolling(self.signal_period).mean()
+
+        df["signal"] = np.where(df["obv"] > df["obv_ma"], 1, -1)
+
+        return df.dropna()

--- a/backend/strategies/rsi.py
+++ b/backend/strategies/rsi.py
@@ -28,6 +28,14 @@ class RSIStrategy(BaseStrategy):
     def name(self) -> str:
         return "rsi"
 
+    @property
+    def description(self) -> str:
+        return "RSI : long sous le seuil de survente, short au-dessus du surachat"
+
+    @property
+    def category(self) -> str:
+        return "momentum"
+
     def compute_signals(self, df: pd.DataFrame) -> pd.DataFrame:
         df = df.copy()
 

--- a/backend/strategies/stochastic.py
+++ b/backend/strategies/stochastic.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pandas as pd
+from .base import BaseStrategy
+
+
+class StochasticStrategy(BaseStrategy):
+    """
+    Stratégie Stochastic Oscillator.
+
+    Signal :
+        +1 si %K < oversold    → survente, rebond probable
+        -1 si %K > overbought  → surachat, correction probable
+         0 sinon               → neutre
+    """
+
+    def __init__(self, k_period: int = 14, d_period: int = 3,
+                 overbought: float = 80.0, oversold: float = 20.0):
+        self.k_period = k_period
+        self.d_period = d_period
+        self.overbought = overbought
+        self.oversold = oversold
+
+    @property
+    def name(self) -> str:
+        return "stochastic"
+
+    @property
+    def description(self) -> str:
+        return "Stochastique : compare le prix au range haut/bas, similaire au RSI"
+
+    @property
+    def category(self) -> str:
+        return "momentum"
+
+    def compute_signals(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+
+        lowest_low = df["Low"].rolling(self.k_period).min()
+        highest_high = df["High"].rolling(self.k_period).max()
+
+        denom = (highest_high - lowest_low).replace(0, np.nan)
+        df["stoch_k"] = 100 * (df["Close"] - lowest_low) / denom
+        df["stoch_d"] = df["stoch_k"].rolling(self.d_period).mean()
+
+        df["signal"] = np.where(
+            df["stoch_k"] < self.oversold, 1,
+            np.where(df["stoch_k"] > self.overbought, -1, 0)
+        )
+
+        return df.dropna()

--- a/frontend/src/app/pages/backtests/backtests.html
+++ b/frontend/src/app/pages/backtests/backtests.html
@@ -23,12 +23,19 @@
   <mat-form-field>
     <mat-label>Stratégie</mat-label>
     <mat-select [value]="strategy()" (selectionChange)="onStrategyChange($event.value)">
-      <mat-option value="macd">MACD</mat-option>
-      <mat-option value="rsi">RSI</mat-option>
-      <mat-option value="ma_crossover">MA Crossover</mat-option>
+      @for (key of strategyKeys(); track key) {
+        <mat-option [value]="key">
+          {{ strategies()[key].name.toUpperCase() }}
+          <span class="strategy-category">[{{ strategies()[key].category }}]</span>
+        </mat-option>
+      }
     </mat-select>
   </mat-form-field>
 </div>
+
+@if (strategies()[strategy()]; as info) {
+  <p class="strategy-hint">{{ info.description }}</p>
+}
 
 <!-- ── Paramètres dynamiques ──────────────────────────────────────────── -->
 <div class="form-row params-row">

--- a/frontend/src/app/pages/backtests/backtests.scss
+++ b/frontend/src/app/pages/backtests/backtests.scss
@@ -1,0 +1,13 @@
+.strategy-category {
+  font-size: 0.7rem;
+  opacity: 0.5;
+  margin-left: 6px;
+  text-transform: uppercase;
+}
+
+.strategy-hint {
+  margin: -8px 0 12px;
+  font-size: 0.8rem;
+  color: #aaa;
+  font-style: italic;
+}

--- a/frontend/src/app/pages/backtests/backtests.ts
+++ b/frontend/src/app/pages/backtests/backtests.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -8,7 +8,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { DataService, BacktestResult, normalizeOldResult } from '../../../services/data-service';
+import { DataService, BacktestResult, normalizeOldResult, StrategyInfo } from '../../../services/data-service';
 import { AuthService } from '../../../services/auth.service';
 import { BacktestHistoryService } from '../../../services/backtest-history.service';
 
@@ -19,9 +19,13 @@ const TICKER_MAP: Record<string, string> = {
 };
 
 const DEFAULT_PARAMS: Record<string, Record<string, number>> = {
-  macd:         { fast: 12, slow: 26, signal: 9 },
-  rsi:          { length: 14, overbought: 70, oversold: 30 },
-  ma_crossover: { fast: 10, slow: 30 },
+  macd:            { fast: 12, slow: 26, signal: 9 },
+  rsi:             { length: 14, overbought: 70, oversold: 30 },
+  ma_crossover:    { fast: 10, slow: 30 },
+  ema_crossover:   { fast: 12, slow: 26 },
+  bollinger_bands: { period: 20, std_dev: 2 },
+  stochastic:      { k_period: 14, d_period: 3, overbought: 80, oversold: 20 },
+  obv:             { signal_period: 20 },
 };
 
 @Component({
@@ -39,7 +43,7 @@ const DEFAULT_PARAMS: Record<string, Record<string, number>> = {
   templateUrl: './backtests.html',
   styleUrl: './backtests.scss',
 })
-export class Backtests {
+export class Backtests implements OnInit {
   private dataService = inject(DataService);
   private auth        = inject(AuthService);
   private router      = inject(Router);
@@ -50,6 +54,15 @@ export class Backtests {
   strategy = signal<string>('macd');
 
   params = signal<Record<string, number>>({ ...DEFAULT_PARAMS['macd'] });
+
+  strategies = signal<Record<string, StrategyInfo>>({});
+  strategyKeys = computed(() => Object.keys(this.strategies()));
+
+  ngOnInit() {
+    this.dataService.getStrategies().subscribe({
+      next: (res) => this.strategies.set(res.strategies),
+    });
+  }
 
   isLoading    = signal<boolean>(false);
   errorMessage = signal<string | null>(null);

--- a/frontend/src/app/pages/results/results.scss
+++ b/frontend/src/app/pages/results/results.scss
@@ -194,6 +194,10 @@
     &.chip-macd    { background: #0d47a1; color: #90caf9; }
     &.chip-rsi     { background: #4a148c; color: #ce93d8; }
     &.chip-ma      { background: #004d40; color: #80cbc4; }
+    &.chip-ema     { background: #1a237e; color: #9fa8da; }
+    &.chip-bb      { background: #bf360c; color: #ffab91; }
+    &.chip-stoch   { background: #880e4f; color: #f48fb1; }
+    &.chip-obv     { background: #33691e; color: #aed581; }
     &.chip-custom  { background: #1b5e20; color: #a5d6a7; }
     &.chip-default { background: #333;    color: #ccc; }
   }

--- a/frontend/src/app/pages/results/results.ts
+++ b/frontend/src/app/pages/results/results.ts
@@ -66,11 +66,18 @@ export class Results implements OnInit {
     return 'sharpe-bad';
   }
 
+  private chipMap: Record<string, string> = {
+    macd:            'chip-macd',
+    rsi:             'chip-rsi',
+    ma_crossover:    'chip-ma',
+    ema_crossover:   'chip-ema',
+    bollinger_bands: 'chip-bb',
+    stochastic:      'chip-stoch',
+    obv:             'chip-obv',
+  };
+
   strategyClass(s: string): string {
-    if (s === 'macd')         return 'chip-macd';
-    if (s === 'rsi')          return 'chip-rsi';
-    if (s === 'ma_crossover') return 'chip-ma';
-    return 'chip-default';
+    return this.chipMap[s] ?? 'chip-default';
   }
 
   metricCards(): MetricCard[] {

--- a/frontend/src/services/data-service.ts
+++ b/frontend/src/services/data-service.ts
@@ -4,6 +4,16 @@ import { Observable } from 'rxjs';
 import { environment } from '../environments/environment';
 
 
+export interface StrategyInfo {
+  name: string;
+  description: string;
+  category: string;
+}
+
+export interface StrategiesResponse {
+  strategies: Record<string, StrategyInfo>;
+}
+
 export interface MarketData {
   Time: string;
   Open: number;
@@ -216,6 +226,10 @@ export function normalizeUploadResult(upload: UploadBacktestResult): NormalizedR
 export class DataService {
   private http = inject(HttpClient);
   private api = environment.apiUrl;
+
+  getStrategies(): Observable<StrategiesResponse> {
+    return this.http.get<StrategiesResponse>(`${this.api}/api/strategies`);
+  }
 
   getMarketData(ticker: string, period: string): Observable<MarketData[]> {
     return this.http.get<MarketData[]>(`${this.api}/api/data/${ticker}?period=${period}`);


### PR DESCRIPTION
## Summary

- Ajout de description et category comme proprietes abstraites sur BaseStrategy
- Mise a jour des 3 strategies existantes (MACD, RSI, MA Crossover) avec ces proprietes
- 4 nouveaux indicateurs : EMA Crossover, Bollinger Bands, Stochastic Oscillator, OBV
- API GET /api/strategies enrichie : retourne nom, description et categorie
- Frontend : dropdown dynamique avec tag categorie, description contextuelle, chip colors sur la page resultats

Closes #51

## Test plan

- [ ] GET /api/strategies retourne 7 entrees avec description/category
- [ ] Backtest avec chaque nouvel indicateur (seul) retourne des resultats valides
- [ ] Dropdown affiche les 7 strategies avec tags [trend]/[momentum]/[volume]
- [ ] Description contextuelle sous le select
- [ ] Chip colors corrects sur la page resultats