### PR TITLE
feat(tickers): ajoute 5 indices internationaux (CAC 40, DAX, FTSE 100, Nikkei 225, Hang Seng)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ memory/
 # Local docs
 CLAUDE.md
 DEV_LOG.md
+code-tracking.md
 
 # Local config
 .claude/

--- a/backend/data.py
+++ b/backend/data.py
@@ -7,9 +7,16 @@ from cache import get_cached_data, store_cached_data
 router = APIRouter()
 
 TICKER_MAP = {
+    # Indices US
     "sp500": "^GSPC",
     "nasdaq": "^IXIC",
     "nq": "NQ=F",
+    # Indices internationaux
+    "cac40": "^FCHI",
+    "dax": "^GDAXI",
+    "ftse100": "^FTSE",
+    "nikkei": "^N225",
+    "hangseng": "^HSI",
 }
 
 PERIOD_CONFIG = {

--- a/frontend/src/app/pages/backtests/backtests.html
+++ b/frontend/src/app/pages/backtests/backtests.html
@@ -5,9 +5,18 @@
   <mat-form-field>
     <mat-label>Indice</mat-label>
     <mat-select [value]="ticker()" (selectionChange)="ticker.set($event.value)">
-      <mat-option value="sp500">S&amp;P 500</mat-option>
-      <mat-option value="nasdaq">Nasdaq</mat-option>
-      <mat-option value="nq">Nasdaq Futures</mat-option>
+      <mat-optgroup label="US">
+        <mat-option value="sp500">S&amp;P 500</mat-option>
+        <mat-option value="nasdaq">Nasdaq</mat-option>
+        <mat-option value="nq">Nasdaq Futures</mat-option>
+      </mat-optgroup>
+      <mat-optgroup label="International">
+        <mat-option value="cac40">CAC 40</mat-option>
+        <mat-option value="dax">DAX</mat-option>
+        <mat-option value="ftse100">FTSE 100</mat-option>
+        <mat-option value="nikkei">Nikkei 225</mat-option>
+        <mat-option value="hangseng">Hang Seng</mat-option>
+      </mat-optgroup>
     </mat-select>
   </mat-form-field>
 

--- a/frontend/src/app/pages/backtests/backtests.ts
+++ b/frontend/src/app/pages/backtests/backtests.ts
@@ -13,9 +13,16 @@ import { AuthService } from '../../../services/auth.service';
 import { BacktestHistoryService } from '../../../services/backtest-history.service';
 
 const TICKER_MAP: Record<string, string> = {
+  // Indices US
   sp500:  '^GSPC',
   nasdaq: '^IXIC',
   nq:     'NQ=F',
+  // Indices internationaux
+  cac40:    '^FCHI',
+  dax:      '^GDAXI',
+  ftse100:  '^FTSE',
+  nikkei:   '^N225',
+  hangseng: '^HSI',
 };
 
 const DEFAULT_PARAMS: Record<string, Record<string, number>> = {

--- a/frontend/src/app/pages/data/data.html
+++ b/frontend/src/app/pages/data/data.html
@@ -4,8 +4,18 @@
   <mat-form-field>
     <mat-label>Data Base</mat-label>
     <mat-select [value]="ticker()" (selectionChange)="ticker.set($event.value)">
-        <mat-option value="sp500">S&P 500</mat-option>
-        <mat-option value="nasdaq">NASDAQ</mat-option>
+        <mat-optgroup label="US">
+            <mat-option value="sp500">S&P 500</mat-option>
+            <mat-option value="nasdaq">NASDAQ</mat-option>
+            <mat-option value="nq">Nasdaq Futures</mat-option>
+        </mat-optgroup>
+        <mat-optgroup label="International">
+            <mat-option value="cac40">CAC 40</mat-option>
+            <mat-option value="dax">DAX</mat-option>
+            <mat-option value="ftse100">FTSE 100</mat-option>
+            <mat-option value="nikkei">Nikkei 225</mat-option>
+            <mat-option value="hangseng">Hang Seng</mat-option>
+        </mat-optgroup>
     </mat-select>
   </mat-form-field>
 


### PR DESCRIPTION
## Quoi
Ajoute 5 indices internationaux aux menus de backtest et de données :
CAC 40 (^FCHI), DAX (^GDAXI), FTSE 100 (^FTSE), Nikkei 225 (^N225), Hang Seng (^HSI).

## Pourquoi
Le catalogue se limitait à 3 actifs US. Élargir à l'Europe + l'Asie rend la
plateforme plus intéressante pour un public plus large (notamment francophone via le CAC 40).

## Détails
- `backend/data.py` : `TICKER_MAP` étendu (source de vérité, couvre backtest + page Data)
- Frontend `backtests.ts/.html` + `data.html` : menus regroupés US / International
- Corrige au passage l'absence de Nasdaq Futures dans le menu de la page Data

## Tests effectués
- `POST /api/backtest` sur `cac40` (256 barres) et symbole brut `^GDAXI` (252 barres) → OK
- `GET /api/data/nikkei?period=1Y` → 244 barres OHLCV
- Frontend recompile sans erreur
