### PR TITLE
Ajout dans l'historique d'une fonctionnalité de tri

### DIFF
--- a/frontend/src/app/components/history-panel/history-panel.html
+++ b/frontend/src/app/components/history-panel/history-panel.html
@@ -16,10 +16,37 @@
 <!-- ── Contenu ── -->
 @if (!loading && (isDemo ? demoHistory.length > 0 : history.length > 0)) {
 
+  <!-- Tri -->
+  <div class="sort-bar">
+
+    <button mat-stroked-button [matMenuTriggerFor]="sortMenu">
+      <mat-icon>sort</mat-icon>
+      Trier par : {{ sortKey() === 'date' ? 'Date' : 'Retour' }}
+      <mat-icon iconSuffix>arrow_drop_down</mat-icon>
+    </button>
+
+    <mat-menu #sortMenu="matMenu">
+      <button mat-menu-item (click)="onSortKey('date')"
+              [class.menu-active]="sortKey() === 'date'">
+        <mat-icon>calendar_today</mat-icon> Date
+      </button>
+      <button mat-menu-item (click)="onSortKey('return')"
+              [class.menu-active]="sortKey() === 'return'">
+        <mat-icon>trending_up</mat-icon> Retour stratégie
+      </button>
+    </mat-menu>
+
+    <button mat-icon-button (click)="toggleDir()"
+            [matTooltip]="sortDir() === 'desc' ? 'Décroissant' : 'Croissant'">
+      <mat-icon>{{ sortDir() === 'desc' ? 'arrow_downward' : 'arrow_upward' }}</mat-icon>
+    </button>
+
+  </div>
+
   <!-- ══ Mode démo ══ -->
   @if (isDemo) {
     <mat-accordion multi>
-      @for (r of demoHistory; track r.ticker + r.strategy) {
+      @for (r of sortedDemo(); track r.ticker + r.strategy) {
         <mat-expansion-panel class="history-expansion">
 
           <!-- En-tête -->
@@ -278,7 +305,7 @@
   <!-- ══ Mode connecté ══ -->
   @if (!isDemo) {
     <mat-accordion multi>
-      @for (r of history; track r.id) {
+      @for (r of sortedRecords(); track r.id) {
         <mat-expansion-panel class="history-expansion">
 
           <mat-expansion-panel-header>

--- a/frontend/src/app/components/history-panel/history-panel.scss
+++ b/frontend/src/app/components/history-panel/history-panel.scss
@@ -16,6 +16,14 @@
 }
 .empty-icon { font-size: 52px; width: 52px; height: 52px; opacity: 0.4; }
 
+/* ── Barre de tri ── */
+.sort-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
 /* ── Accordéon ── */
 .history-expansion {
   margin-bottom: 6px;

--- a/frontend/src/app/components/history-panel/history-panel.ts
+++ b/frontend/src/app/components/history-panel/history-panel.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, signal, computed } from '@angular/core';
 import { DatePipe, DecimalPipe } from '@angular/common';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatCardModule } from '@angular/material/card';
@@ -10,6 +10,8 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatMenuModule } from '@angular/material/menu';
 import { BacktestRecord, NormalizedResult } from '../../../services/data-service';
 
 @Component({
@@ -19,6 +21,7 @@ import { BacktestRecord, NormalizedResult } from '../../../services/data-service
     MatExpansionModule, MatCardModule, MatIconModule, MatButtonModule,
     MatChipsModule, MatProgressBarModule, MatDividerModule,
     MatTooltipModule, MatBadgeModule, MatProgressSpinnerModule,
+    MatButtonToggleModule, MatMenuModule,
   ],
   templateUrl: './history-panel.html',
   styleUrl:    './history-panel.scss',
@@ -29,6 +32,30 @@ export class HistoryPanelComponent {
   @Input() isDemo  = false;
   @Input() loading = false;
   @Output() deleted = new EventEmitter<number>();
+
+  sortKey = signal<'date' | 'return'>('date');
+  sortDir = signal<'asc' | 'desc'>('desc');
+
+  sortedDemo = computed(() =>
+    [...this.demoHistory].sort((a, b) => {
+      const d = this.sortKey() === 'return'
+        ? a.metrics.total_return_pct - b.metrics.total_return_pct
+        : 0;
+      return this.sortDir() === 'asc' ? d : -d;
+    })
+  );
+
+  sortedRecords = computed(() =>
+    [...this.history].sort((a, b) => {
+      let d = 0;
+      if (this.sortKey() === 'date')   d = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+      if (this.sortKey() === 'return') d = a.total_return_strat - b.total_return_strat;
+      return this.sortDir() === 'asc' ? d : -d;
+    })
+  );
+
+  onSortKey(k: 'date' | 'return') { this.sortKey.set(k); }
+  toggleDir() { this.sortDir.update(d => d === 'asc' ? 'desc' : 'asc'); }
 
   pct(v: number, decimals = 2): string {
     return (v >= 0 ? '+' : '') + v.toFixed(decimals) + '%';


### PR DESCRIPTION
Dans l'historique on peut maintenant trier nos anciens backtest selon la date ou le retour finacier on aussi aussi la possibilité de trier par ordre croissant ou décroissant